### PR TITLE
Use product class instead of product code

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-VERTEX_TRUSTED_ID=12345
-VERTEX_SOAP_API=https://vertex-soap-api.com
+VERTEX_TRUSTED_ID=secret
+VERTEX_SOAP_API=https://connect.vertexsmb.com/vertex-ws/services/CalculateTax70

--- a/README.md
+++ b/README.md
@@ -27,19 +27,24 @@ response = VertexClient.quotation(
   },
   line_items: [
     {
-      product_code: "t-shirts",
+      # Internal product ID or code
+      product_code: "4600",
+      # Mapped product class, or "commodity code", in Vertex Cloud
+      product_class: "123456"
       quantity: 7,
+      # Total price of this line item
       price: "35.50",
     },
     {
-      product_code: "t-shirts",
+      product_code: "5200",
+      product_class: "123456"
       quantity: 4,
       price: "25.40",
       # Optional transaction date override for a line item.
       date: '2018-11-14',
       # Optional seller override for a line item.
       seller: {
-        company: "Custom Ink Stores"
+        company: "CustomInkStores"
       },
       # Optional customer override for a line item.
       customer: {

--- a/lib/vertex_client/payload.rb
+++ b/lib/vertex_client/payload.rb
@@ -47,7 +47,7 @@ module VertexClient
         :'@taxDate' =>  line_item[:date] || defaults[:date],
         customer:       transform_customer(line_item[:customer] || defaults[:customer]),
         seller:         transform_seller(line_item[:seller] || defaults[:seller]),
-        product:        line_item[:product_code],
+        product:        { :'@productClass' => line_item[:product_code] },
         quantity:       line_item[:quantity],
         extended_price: line_item[:price],
       })

--- a/lib/vertex_client/payload.rb
+++ b/lib/vertex_client/payload.rb
@@ -47,10 +47,17 @@ module VertexClient
         :'@taxDate' =>  line_item[:date] || defaults[:date],
         customer:       transform_customer(line_item[:customer] || defaults[:customer]),
         seller:         transform_seller(line_item[:seller] || defaults[:seller]),
-        product:        { :'@productClass' => line_item[:product_code] },
+        product:        transform_product(line_item),
         quantity:       line_item[:quantity],
         extended_price: line_item[:price],
       })
+    end
+
+    def transform_product(line_item)
+      {
+        :'@productClass' => line_item[:product_class],
+        :content! => line_item[:product_code]
+      }
     end
 
     def transform_customer(customer)

--- a/lib/vertex_client/version.rb
+++ b/lib/vertex_client/version.rb
@@ -1,3 +1,3 @@
 module VertexClient
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end

--- a/test/cassettes/distribute_tax.yml
+++ b/test/cassettes/distribute_tax.yml
@@ -10,14 +10,15 @@ http_interactions:
         xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"><soapenv:Body><urn:VertexEnvelope><Login><TrustedId>{VERTEX_TRUSTED_ID}</TrustedId></Login><DistributeTaxRequest
         transactionType="SALE" documentNumber="test123" documentDate="2018-11-15"><LineItem
         lineItemNumber="1" taxDate="2018-11-14"><Customer><Destination><StreetAddress1>2910
-        District Ave #300</StreetAddress1><City>Fairfax</City><MainDivision>VA</MainDivision><PostalCode>22031</PostalCode></Destination></Customer><Seller><Company>CustomInk</Company></Seller><Product>t-shirts</Product><Quantity>4</Quantity><ExtendedPrice>25.40</ExtendedPrice><InputTotalTax>5.00</InputTotalTax></LineItem></DistributeTaxRequest></urn:VertexEnvelope></soapenv:Body></soapenv:Envelope>'
+        District Ave #300</StreetAddress1><City>Fairfax</City><MainDivision>VA</MainDivision><PostalCode>22031</PostalCode></Destination></Customer><Seller><Company>CustomInk</Company></Seller><Product
+        productClass="53103000"></Product><Quantity>4</Quantity><ExtendedPrice>25.40</ExtendedPrice><InputTotalTax>5.00</InputTotalTax></LineItem></DistributeTaxRequest></urn:VertexEnvelope></soapenv:Body></soapenv:Envelope>'
     headers:
       Soapaction:
       - '"VertexEnvelope"'
       Content-Type:
       - text/xml;charset=UTF-8
       Content-Length:
-      - '928'
+      - '944'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -30,7 +31,7 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Wed, 28 Nov 2018 17:59:15 GMT
+      - Thu, 29 Nov 2018 15:27:29 GMT
       Content-Type:
       - text/xml;charset=UTF-8
       Transfer-Encoding:
@@ -59,7 +60,7 @@ http_interactions:
         <PostalCode>22031</PostalCode>
         </Destination>
         </Customer>
-        <Product>t-shirts</Product>
+        <Product productClass="53103000"></Product>
         <Quantity>4.0</Quantity>
         <ExtendedPrice>25.4</ExtendedPrice>
         <InputTotalTax>5.0</InputTotalTax>
@@ -90,9 +91,9 @@ http_interactions:
         <TotalTax>5.0</TotalTax>
         </LineItem>
         </DistributeTaxResponse>
-        <ApplicationData><ResponseTimeMS>46.7</ResponseTimeMS>
+        <ApplicationData><ResponseTimeMS>12</ResponseTimeMS>
         </ApplicationData>
         </VertexEnvelope></soapenv:Body></soapenv:Envelope>
     http_version: 
-  recorded_at: Wed, 28 Nov 2018 17:59:15 GMT
+  recorded_at: Thu, 29 Nov 2018 15:27:29 GMT
 recorded_with: VCR 4.0.0

--- a/test/cassettes/distribute_tax.yml
+++ b/test/cassettes/distribute_tax.yml
@@ -11,14 +11,14 @@ http_interactions:
         transactionType="SALE" documentNumber="test123" documentDate="2018-11-15"><LineItem
         lineItemNumber="1" taxDate="2018-11-14"><Customer><Destination><StreetAddress1>2910
         District Ave #300</StreetAddress1><City>Fairfax</City><MainDivision>VA</MainDivision><PostalCode>22031</PostalCode></Destination></Customer><Seller><Company>CustomInk</Company></Seller><Product
-        productClass="53103000"></Product><Quantity>4</Quantity><ExtendedPrice>25.40</ExtendedPrice><InputTotalTax>5.00</InputTotalTax></LineItem></DistributeTaxRequest></urn:VertexEnvelope></soapenv:Body></soapenv:Envelope>'
+        productClass="53103000">5300</Product><Quantity>4</Quantity><ExtendedPrice>25.40</ExtendedPrice><InputTotalTax>5.00</InputTotalTax></LineItem></DistributeTaxRequest></urn:VertexEnvelope></soapenv:Body></soapenv:Envelope>'
     headers:
       Soapaction:
       - '"VertexEnvelope"'
       Content-Type:
       - text/xml;charset=UTF-8
       Content-Length:
-      - '944'
+      - '948'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -31,7 +31,7 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Thu, 29 Nov 2018 15:27:29 GMT
+      - Thu, 29 Nov 2018 19:32:08 GMT
       Content-Type:
       - text/xml;charset=UTF-8
       Transfer-Encoding:
@@ -60,7 +60,7 @@ http_interactions:
         <PostalCode>22031</PostalCode>
         </Destination>
         </Customer>
-        <Product productClass="53103000"></Product>
+        <Product productClass="53103000">5300</Product>
         <Quantity>4.0</Quantity>
         <ExtendedPrice>25.4</ExtendedPrice>
         <InputTotalTax>5.0</InputTotalTax>
@@ -91,9 +91,9 @@ http_interactions:
         <TotalTax>5.0</TotalTax>
         </LineItem>
         </DistributeTaxResponse>
-        <ApplicationData><ResponseTimeMS>12</ResponseTimeMS>
+        <ApplicationData><ResponseTimeMS>18.8</ResponseTimeMS>
         </ApplicationData>
         </VertexEnvelope></soapenv:Body></soapenv:Envelope>
     http_version: 
-  recorded_at: Thu, 29 Nov 2018 15:27:29 GMT
+  recorded_at: Thu, 29 Nov 2018 19:32:08 GMT
 recorded_with: VCR 4.0.0

--- a/test/cassettes/invoice.yml
+++ b/test/cassettes/invoice.yml
@@ -5,21 +5,23 @@ http_interactions:
     uri: "{VERTEX_SOAP_API}"
     body:
       encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+      string: '<?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:urn="urn:vertexinc:o-series:tps:7:0"
         xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"><soapenv:Body><urn:VertexEnvelope><Login><TrustedId>{VERTEX_TRUSTED_ID}</TrustedId></Login><InvoiceRequest
         transactionType="SALE" documentNumber="test123" documentDate="2018-11-15"><LineItem
         lineItemNumber="1" taxDate="2018-11-15"><Customer><Destination><StreetAddress1>11
-        Wall Street</StreetAddress1><City>New York</City><MainDivision>NY</MainDivision><PostalCode>10005</PostalCode></Destination></Customer><Seller><Company>CustomInk</Company></Seller><Product>t-shirts</Product><Quantity>7</Quantity><ExtendedPrice>35.50</ExtendedPrice></LineItem><LineItem
-        lineItemNumber="2" taxDate="2018-11-14"><Customer><Destination><StreetAddress1>1600
-        Pennsylvania Ave NW</StreetAddress1><City>Washington</City><MainDivision>DC</MainDivision><PostalCode>20500</PostalCode></Destination></Customer><Seller><Company>CustomInk</Company></Seller><Product>t-shirts</Product><Quantity>4</Quantity><ExtendedPrice>25.40</ExtendedPrice><Discount><DiscountAmount>2.23</DiscountAmount></Discount></LineItem><Discount><DiscountAmount>5.40</DiscountAmount></Discount></InvoiceRequest></urn:VertexEnvelope></soapenv:Body></soapenv:Envelope>
+        Wall Street</StreetAddress1><City>New York</City><MainDivision>NY</MainDivision><PostalCode>10005</PostalCode></Destination></Customer><Seller><Company>CustomInk</Company></Seller><Product
+        productClass="53103000"></Product><Quantity>7</Quantity><ExtendedPrice>35.50</ExtendedPrice></LineItem><LineItem
+        lineItemNumber="2" taxDate="2018-11-14"><Customer><Destination><StreetAddress1>2910
+        District Ave #300</StreetAddress1><City>Fairfax</City><MainDivision>VA</MainDivision><PostalCode>22031</PostalCode></Destination></Customer><Seller><Company>CustomInk</Company></Seller><Product
+        productClass="53103000"></Product><Quantity>4</Quantity><ExtendedPrice>25.40</ExtendedPrice></LineItem></InvoiceRequest></urn:VertexEnvelope></soapenv:Body></soapenv:Envelope>'
     headers:
       Soapaction:
       - '"VertexEnvelope"'
       Content-Type:
       - text/xml;charset=UTF-8
       Content-Length:
-      - '1370'
+      - '1281'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -32,7 +34,7 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Tue, 27 Nov 2018 12:37:08 GMT
+      - Thu, 29 Nov 2018 15:27:29 GMT
       Content-Type:
       - text/xml;charset=UTF-8
       Transfer-Encoding:
@@ -50,11 +52,9 @@ http_interactions:
       string: |-
         <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"><soapenv:Header></soapenv:Header><soapenv:Body><VertexEnvelope xmlns="urn:vertexinc:o-series:tps:7:0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Login><TrustedId></TrustedId>
         </Login>
-        <InvoiceResponse documentNumber="test123" documentDate="2018-11-15" transactionType="SALE"><Discount><DiscountAmount>5.4</DiscountAmount>
-        </Discount>
-        <SubTotal>60.9</SubTotal>
-        <Total>60.9</Total>
-        <TotalTax>0.0</TotalTax>
+        <InvoiceResponse documentNumber="test123" documentDate="2018-11-15" transactionType="SALE"><SubTotal>60.9</SubTotal>
+        <Total>62.42</Total>
+        <TotalTax>1.52</TotalTax>
         <LineItem lineItemNumber="1"><Seller><Company>CustomInk</Company>
         </Seller>
         <Customer><Destination taxAreaId="330612010"><StreetAddress1>11 Wall Street</StreetAddress1>
@@ -63,12 +63,10 @@ http_interactions:
         <PostalCode>10005</PostalCode>
         </Destination>
         </Customer>
-        <Product>t-shirts</Product>
+        <Product productClass="53103000"></Product>
         <Quantity>7.0</Quantity>
-        <FairMarketValue>38.537</FairMarketValue>
+        <FairMarketValue>35.5</FairMarketValue>
         <ExtendedPrice>35.5</ExtendedPrice>
-        <Discount><DiscountAmount>3.037</DiscountAmount>
-        </Discount>
         <Taxes taxResult="NO_TAX" taxType="SALES" situs="DESTINATION" notRegisteredIndicator="true" taxCollectedFromParty="BUYER"><Jurisdiction jurisdictionLevel="STATE" jurisdictionId="24354">NEW YORK</Jurisdiction>
         <CalculatedTax>0.0</CalculatedTax>
         <EffectiveRate>0.0</EffectiveRate>
@@ -83,7 +81,7 @@ http_interactions:
         <Imposition impositionId="1">Local Sales and Use Tax</Imposition>
         <ImpositionType impositionTypeId="1">General Sales and Use Tax</ImpositionType>
         </Taxes>
-        <Taxes taxResult="NO_TAX" taxType="SALES" situs="DESTINATION" notRegisteredIndicator="true" taxCollectedFromParty="BUYER"><Jurisdiction jurisdictionLevel="DISTRICT" jurisdictionId="79774"><![CDATA[METROPOLITAN COMMUTER TRANSPORT]]><![CDATA[ATION DISTRICT]]></Jurisdiction>
+        <Taxes taxResult="NO_TAX" taxType="SALES" situs="DESTINATION" notRegisteredIndicator="true" taxCollectedFromParty="BUYER"><Jurisdiction jurisdictionLevel="DISTRICT" jurisdictionId="79774"><![CDATA[METROPOLITAN COMMUTER TRANSPORTATION DISTRICT]]></Jurisdiction>
         <CalculatedTax>0.0</CalculatedTax>
         <EffectiveRate>0.0</EffectiveRate>
         <Taxable>0.0</Taxable>
@@ -94,31 +92,46 @@ http_interactions:
         </LineItem>
         <LineItem lineItemNumber="2" taxDate="2018-11-14"><Seller><Company>CustomInk</Company>
         </Seller>
-        <Customer><Destination taxAreaId="90010010"><StreetAddress1>1600 Pennsylvania Ave NW</StreetAddress1>
-        <City>Washington</City>
-        <MainDivision>DC</MainDivision>
-        <PostalCode>20500</PostalCode>
+        <Customer><Destination taxAreaId="470590000"><StreetAddress1>2910 District Ave #300</StreetAddress1>
+        <City>Fairfax</City>
+        <MainDivision>VA</MainDivision>
+        <PostalCode>22031</PostalCode>
         </Destination>
         </Customer>
-        <Product>t-shirts</Product>
+        <Product productClass="53103000"></Product>
         <Quantity>4.0</Quantity>
-        <FairMarketValue>29.993</FairMarketValue>
+        <FairMarketValue>25.4</FairMarketValue>
         <ExtendedPrice>25.4</ExtendedPrice>
-        <Discount><DiscountAmount>4.593</DiscountAmount>
-        </Discount>
-        <Taxes taxResult="NO_TAX" taxType="SALES" situs="DESTINATION" notRegisteredIndicator="true" taxCollectedFromParty="BUYER"><Jurisdiction jurisdictionLevel="STATE" jurisdictionId="5283">DISTRICT OF COLUMBIA</Jurisdiction>
-        <CalculatedTax>0.0</CalculatedTax>
-        <EffectiveRate>0.0</EffectiveRate>
-        <Taxable>0.0</Taxable>
-        <Imposition impositionId="1"><![CDATA[Gross Sales and Compensating Use Tax]]></Imposition>
+        <Taxes taxResult="TAXABLE" taxType="SALES" situs="DESTINATION" taxCollectedFromParty="BUYER" taxStructure="SINGLE_RATE"><Jurisdiction jurisdictionLevel="STATE" jurisdictionId="39067">VIRGINIA</Jurisdiction>
+        <CalculatedTax>1.09</CalculatedTax>
+        <EffectiveRate>0.043</EffectiveRate>
+        <Taxable>25.4</Taxable>
+        <Imposition impositionId="1">Retail Sales and Use Tax</Imposition>
         <ImpositionType impositionTypeId="1">General Sales and Use Tax</ImpositionType>
+        <TaxRuleId>510815</TaxRuleId>
         </Taxes>
-        <TotalTax>0.0</TotalTax>
+        <Taxes taxResult="TAXABLE" taxType="SALES" situs="DESTINATION" taxCollectedFromParty="BUYER" taxStructure="SINGLE_RATE"><Jurisdiction jurisdictionLevel="COUNTY" jurisdictionId="39378">FAIRFAX</Jurisdiction>
+        <CalculatedTax>0.25</CalculatedTax>
+        <EffectiveRate>0.01</EffectiveRate>
+        <Taxable>25.4</Taxable>
+        <Imposition impositionId="1">Local Sales and Use Tax</Imposition>
+        <ImpositionType impositionTypeId="1">General Sales and Use Tax</ImpositionType>
+        <TaxRuleId>23410</TaxRuleId>
+        </Taxes>
+        <Taxes taxResult="TAXABLE" taxType="SALES" situs="DESTINATION" taxCollectedFromParty="BUYER" taxStructure="SINGLE_RATE"><Jurisdiction jurisdictionLevel="DISTRICT" jurisdictionId="97100">REGIONAL TRANSPORTATION DISTRICT</Jurisdiction>
+        <CalculatedTax>0.18</CalculatedTax>
+        <EffectiveRate>0.007</EffectiveRate>
+        <Taxable>25.4</Taxable>
+        <Imposition impositionId="1">Local Sales and Use Tax</Imposition>
+        <ImpositionType impositionTypeId="1">General Sales and Use Tax</ImpositionType>
+        <TaxRuleId>510824</TaxRuleId>
+        </Taxes>
+        <TotalTax>1.52</TotalTax>
         </LineItem>
         </InvoiceResponse>
-        <ApplicationData><ResponseTimeMS>36.9</ResponseTimeMS>
+        <ApplicationData><ResponseTimeMS>13.2</ResponseTimeMS>
         </ApplicationData>
         </VertexEnvelope></soapenv:Body></soapenv:Envelope>
     http_version: 
-  recorded_at: Tue, 27 Nov 2018 12:37:08 GMT
+  recorded_at: Thu, 29 Nov 2018 15:27:29 GMT
 recorded_with: VCR 4.0.0

--- a/test/cassettes/invoice.yml
+++ b/test/cassettes/invoice.yml
@@ -11,17 +11,17 @@ http_interactions:
         transactionType="SALE" documentNumber="test123" documentDate="2018-11-15"><LineItem
         lineItemNumber="1" taxDate="2018-11-15"><Customer><Destination><StreetAddress1>11
         Wall Street</StreetAddress1><City>New York</City><MainDivision>NY</MainDivision><PostalCode>10005</PostalCode></Destination></Customer><Seller><Company>CustomInk</Company></Seller><Product
-        productClass="53103000"></Product><Quantity>7</Quantity><ExtendedPrice>35.50</ExtendedPrice></LineItem><LineItem
+        productClass="53103000">4600</Product><Quantity>7</Quantity><ExtendedPrice>35.50</ExtendedPrice></LineItem><LineItem
         lineItemNumber="2" taxDate="2018-11-14"><Customer><Destination><StreetAddress1>2910
         District Ave #300</StreetAddress1><City>Fairfax</City><MainDivision>VA</MainDivision><PostalCode>22031</PostalCode></Destination></Customer><Seller><Company>CustomInk</Company></Seller><Product
-        productClass="53103000"></Product><Quantity>4</Quantity><ExtendedPrice>25.40</ExtendedPrice></LineItem></InvoiceRequest></urn:VertexEnvelope></soapenv:Body></soapenv:Envelope>'
+        productClass="53103000">5300</Product><Quantity>4</Quantity><ExtendedPrice>25.40</ExtendedPrice></LineItem></InvoiceRequest></urn:VertexEnvelope></soapenv:Body></soapenv:Envelope>'
     headers:
       Soapaction:
       - '"VertexEnvelope"'
       Content-Type:
       - text/xml;charset=UTF-8
       Content-Length:
-      - '1281'
+      - '1289'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -34,7 +34,7 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Thu, 29 Nov 2018 15:27:29 GMT
+      - Thu, 29 Nov 2018 19:32:08 GMT
       Content-Type:
       - text/xml;charset=UTF-8
       Transfer-Encoding:
@@ -63,7 +63,7 @@ http_interactions:
         <PostalCode>10005</PostalCode>
         </Destination>
         </Customer>
-        <Product productClass="53103000"></Product>
+        <Product productClass="53103000">4600</Product>
         <Quantity>7.0</Quantity>
         <FairMarketValue>35.5</FairMarketValue>
         <ExtendedPrice>35.5</ExtendedPrice>
@@ -98,7 +98,7 @@ http_interactions:
         <PostalCode>22031</PostalCode>
         </Destination>
         </Customer>
-        <Product productClass="53103000"></Product>
+        <Product productClass="53103000">5300</Product>
         <Quantity>4.0</Quantity>
         <FairMarketValue>25.4</FairMarketValue>
         <ExtendedPrice>25.4</ExtendedPrice>
@@ -129,9 +129,9 @@ http_interactions:
         <TotalTax>1.52</TotalTax>
         </LineItem>
         </InvoiceResponse>
-        <ApplicationData><ResponseTimeMS>13.2</ResponseTimeMS>
+        <ApplicationData><ResponseTimeMS>39.7</ResponseTimeMS>
         </ApplicationData>
         </VertexEnvelope></soapenv:Body></soapenv:Envelope>
     http_version: 
-  recorded_at: Thu, 29 Nov 2018 15:27:29 GMT
+  recorded_at: Thu, 29 Nov 2018 19:32:08 GMT
 recorded_with: VCR 4.0.0

--- a/test/cassettes/quotation.yml
+++ b/test/cassettes/quotation.yml
@@ -10,17 +10,17 @@ http_interactions:
         xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"><soapenv:Body><urn:VertexEnvelope><Login><TrustedId>{VERTEX_TRUSTED_ID}</TrustedId></Login><QuotationRequest
         transactionType="SALE"><LineItem lineItemNumber="1" taxDate="2018-11-15"><Customer><Destination><StreetAddress1>11
         Wall Street</StreetAddress1><City>New York</City><MainDivision>NY</MainDivision><PostalCode>10005</PostalCode></Destination></Customer><Seller><Company>CustomInk</Company></Seller><Product
-        productClass="53103000"></Product><Quantity>7</Quantity><ExtendedPrice>35.50</ExtendedPrice></LineItem><LineItem
+        productClass="53103000">4600</Product><Quantity>7</Quantity><ExtendedPrice>35.50</ExtendedPrice></LineItem><LineItem
         lineItemNumber="2" taxDate="2018-11-14"><Customer><Destination><StreetAddress1>2910
         District Ave #300</StreetAddress1><City>Fairfax</City><MainDivision>VA</MainDivision><PostalCode>22031</PostalCode></Destination></Customer><Seller><Company>CustomInk</Company></Seller><Product
-        productClass="53103000"></Product><Quantity>4</Quantity><ExtendedPrice>25.40</ExtendedPrice></LineItem></QuotationRequest></urn:VertexEnvelope></soapenv:Body></soapenv:Envelope>'
+        productClass="53103000">5300</Product><Quantity>4</Quantity><ExtendedPrice>25.40</ExtendedPrice></LineItem></QuotationRequest></urn:VertexEnvelope></soapenv:Body></soapenv:Envelope>'
     headers:
       Soapaction:
       - '"VertexEnvelope"'
       Content-Type:
       - text/xml;charset=UTF-8
       Content-Length:
-      - '1234'
+      - '1242'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -33,7 +33,7 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Thu, 29 Nov 2018 15:27:29 GMT
+      - Thu, 29 Nov 2018 19:32:08 GMT
       Content-Type:
       - text/xml;charset=UTF-8
       Transfer-Encoding:
@@ -62,7 +62,7 @@ http_interactions:
         <PostalCode>10005</PostalCode>
         </Destination>
         </Customer>
-        <Product productClass="53103000"></Product>
+        <Product productClass="53103000">4600</Product>
         <Quantity>7.0</Quantity>
         <FairMarketValue>35.5</FairMarketValue>
         <ExtendedPrice>35.5</ExtendedPrice>
@@ -97,7 +97,7 @@ http_interactions:
         <PostalCode>22031</PostalCode>
         </Destination>
         </Customer>
-        <Product productClass="53103000"></Product>
+        <Product productClass="53103000">5300</Product>
         <Quantity>4.0</Quantity>
         <FairMarketValue>25.4</FairMarketValue>
         <ExtendedPrice>25.4</ExtendedPrice>
@@ -128,9 +128,9 @@ http_interactions:
         <TotalTax>1.52</TotalTax>
         </LineItem>
         </QuotationResponse>
-        <ApplicationData><ResponseTimeMS>13.6</ResponseTimeMS>
+        <ApplicationData><ResponseTimeMS>47.2</ResponseTimeMS>
         </ApplicationData>
         </VertexEnvelope></soapenv:Body></soapenv:Envelope>
     http_version: 
-  recorded_at: Thu, 29 Nov 2018 15:27:29 GMT
+  recorded_at: Thu, 29 Nov 2018 19:32:08 GMT
 recorded_with: VCR 4.0.0

--- a/test/cassettes/quotation.yml
+++ b/test/cassettes/quotation.yml
@@ -5,20 +5,22 @@ http_interactions:
     uri: "{VERTEX_SOAP_API}"
     body:
       encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+      string: '<?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:urn="urn:vertexinc:o-series:tps:7:0"
         xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"><soapenv:Body><urn:VertexEnvelope><Login><TrustedId>{VERTEX_TRUSTED_ID}</TrustedId></Login><QuotationRequest
-        transactionType="SALE"><LineItem lineItemNumber="0"><Date>2018-11-15</Date><Customer><Destination><StreetAddress1>11
-        Wall Street</StreetAddress1><City>New York</City><MainDivision>NY</MainDivision><PostalCode>10005</PostalCode></Destination></Customer><Seller><Company>CustomInk</Company></Seller><Product>t-shirts</Product><Quantity>7</Quantity><ExtendedPrice>35.50</ExtendedPrice></LineItem><LineItem
-        lineItemNumber="1"><Date>2018-11-14</Date><Customer><Destination><StreetAddress1>1600
-        Pennsylvania Ave NW</StreetAddress1><City>Washington</City><MainDivision>DC</MainDivision><PostalCode>20500</PostalCode></Destination></Customer><Seller><Company>CustomInkStores</Company></Seller><Product>t-shirts</Product><Quantity>4</Quantity><ExtendedPrice>25.40</ExtendedPrice><Discount><DiscountAmount>2.23</DiscountAmount></Discount></LineItem><Discount><DiscountAmount>5.40</DiscountAmount></Discount></QuotationRequest></urn:VertexEnvelope></soapenv:Body></soapenv:Envelope>
+        transactionType="SALE"><LineItem lineItemNumber="1" taxDate="2018-11-15"><Customer><Destination><StreetAddress1>11
+        Wall Street</StreetAddress1><City>New York</City><MainDivision>NY</MainDivision><PostalCode>10005</PostalCode></Destination></Customer><Seller><Company>CustomInk</Company></Seller><Product
+        productClass="53103000"></Product><Quantity>7</Quantity><ExtendedPrice>35.50</ExtendedPrice></LineItem><LineItem
+        lineItemNumber="2" taxDate="2018-11-14"><Customer><Destination><StreetAddress1>2910
+        District Ave #300</StreetAddress1><City>Fairfax</City><MainDivision>VA</MainDivision><PostalCode>22031</PostalCode></Destination></Customer><Seller><Company>CustomInk</Company></Seller><Product
+        productClass="53103000"></Product><Quantity>4</Quantity><ExtendedPrice>25.40</ExtendedPrice></LineItem></QuotationRequest></urn:VertexEnvelope></soapenv:Body></soapenv:Envelope>'
     headers:
       Soapaction:
       - '"VertexEnvelope"'
       Content-Type:
       - text/xml;charset=UTF-8
       Content-Length:
-      - '1333'
+      - '1234'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -31,7 +33,7 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Mon, 26 Nov 2018 19:47:17 GMT
+      - Thu, 29 Nov 2018 15:27:29 GMT
       Content-Type:
       - text/xml;charset=UTF-8
       Transfer-Encoding:
@@ -49,12 +51,10 @@ http_interactions:
       string: |-
         <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"><soapenv:Header></soapenv:Header><soapenv:Body><VertexEnvelope xmlns="urn:vertexinc:o-series:tps:7:0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Login><TrustedId></TrustedId>
         </Login>
-        <QuotationResponse documentDate="2018-11-26" transactionType="SALE"><Discount><DiscountAmount>5.4</DiscountAmount>
-        </Discount>
-        <SubTotal>60.9</SubTotal>
+        <QuotationResponse documentDate="2018-11-29" transactionType="SALE"><SubTotal>60.9</SubTotal>
         <Total>62.42</Total>
         <TotalTax>1.52</TotalTax>
-        <LineItem lineItemNumber="0"><Seller><Company>CustomInk</Company>
+        <LineItem lineItemNumber="1" taxDate="2018-11-15"><Seller><Company>CustomInk</Company>
         </Seller>
         <Customer><Destination taxAreaId="330612010"><StreetAddress1>11 Wall Street</StreetAddress1>
         <City>New York</City>
@@ -62,12 +62,10 @@ http_interactions:
         <PostalCode>10005</PostalCode>
         </Destination>
         </Customer>
-        <Product>t-shirts</Product>
+        <Product productClass="53103000"></Product>
         <Quantity>7.0</Quantity>
-        <FairMarketValue>38.537</FairMarketValue>
+        <FairMarketValue>35.5</FairMarketValue>
         <ExtendedPrice>35.5</ExtendedPrice>
-        <Discount><DiscountAmount>3.037</DiscountAmount>
-        </Discount>
         <Taxes taxResult="NO_TAX" taxType="SALES" situs="DESTINATION" notRegisteredIndicator="true" taxCollectedFromParty="BUYER"><Jurisdiction jurisdictionLevel="STATE" jurisdictionId="24354">NEW YORK</Jurisdiction>
         <CalculatedTax>0.0</CalculatedTax>
         <EffectiveRate>0.0</EffectiveRate>
@@ -91,35 +89,48 @@ http_interactions:
         </Taxes>
         <TotalTax>0.0</TotalTax>
         </LineItem>
-        <LineItem lineItemNumber="1"><Seller><Company>CustomInkStores</Company>
+        <LineItem lineItemNumber="2" taxDate="2018-11-14"><Seller><Company>CustomInk</Company>
         </Seller>
-        <Customer><Destination taxAreaId="90010010"><StreetAddress1>1600 Pennsylvania Ave NW</StreetAddress1>
-        <City>Washington</City>
-        <MainDivision>DC</MainDivision>
-        <PostalCode>20500</PostalCode>
+        <Customer><Destination taxAreaId="470590000"><StreetAddress1>2910 District Ave #300</StreetAddress1>
+        <City>Fairfax</City>
+        <MainDivision>VA</MainDivision>
+        <PostalCode>22031</PostalCode>
         </Destination>
         </Customer>
-        <Product>t-shirts</Product>
+        <Product productClass="53103000"></Product>
         <Quantity>4.0</Quantity>
-        <FairMarketValue>29.993</FairMarketValue>
+        <FairMarketValue>25.4</FairMarketValue>
         <ExtendedPrice>25.4</ExtendedPrice>
-        <Discount><DiscountAmount>4.593</DiscountAmount>
-        </Discount>
-        <Taxes taxResult="TAXABLE" taxType="SALES" situs="DESTINATION" taxCollectedFromParty="BUYER" taxStructure="SINGLE_RATE"><Jurisdiction jurisdictionLevel="STATE" jurisdictionId="5283">DISTRICT OF COLUMBIA</Jurisdiction>
-        <CalculatedTax>1.52</CalculatedTax>
-        <EffectiveRate>0.06</EffectiveRate>
+        <Taxes taxResult="TAXABLE" taxType="SALES" situs="DESTINATION" taxCollectedFromParty="BUYER" taxStructure="SINGLE_RATE"><Jurisdiction jurisdictionLevel="STATE" jurisdictionId="39067">VIRGINIA</Jurisdiction>
+        <CalculatedTax>1.09</CalculatedTax>
+        <EffectiveRate>0.043</EffectiveRate>
         <Taxable>25.4</Taxable>
-        <Imposition impositionId="1"><![CDATA[Gross Sales and Compensating Use Tax]]></Imposition>
+        <Imposition impositionId="1">Retail Sales and Use Tax</Imposition>
         <ImpositionType impositionTypeId="1">General Sales and Use Tax</ImpositionType>
-        <TaxRuleId>7757835</TaxRuleId>
-        <BasisRuleId>71372</BasisRuleId>
+        <TaxRuleId>510815</TaxRuleId>
+        </Taxes>
+        <Taxes taxResult="TAXABLE" taxType="SALES" situs="DESTINATION" taxCollectedFromParty="BUYER" taxStructure="SINGLE_RATE"><Jurisdiction jurisdictionLevel="COUNTY" jurisdictionId="39378">FAIRFAX</Jurisdiction>
+        <CalculatedTax>0.25</CalculatedTax>
+        <EffectiveRate>0.01</EffectiveRate>
+        <Taxable>25.4</Taxable>
+        <Imposition impositionId="1">Local Sales and Use Tax</Imposition>
+        <ImpositionType impositionTypeId="1">General Sales and Use Tax</ImpositionType>
+        <TaxRuleId>23410</TaxRuleId>
+        </Taxes>
+        <Taxes taxResult="TAXABLE" taxType="SALES" situs="DESTINATION" taxCollectedFromParty="BUYER" taxStructure="SINGLE_RATE"><Jurisdiction jurisdictionLevel="DISTRICT" jurisdictionId="97100">REGIONAL TRANSPORTATION DISTRICT</Jurisdiction>
+        <CalculatedTax>0.18</CalculatedTax>
+        <EffectiveRate>0.007</EffectiveRate>
+        <Taxable>25.4</Taxable>
+        <Imposition impositionId="1">Local Sales and Use Tax</Imposition>
+        <ImpositionType impositionTypeId="1">General Sales and Use Tax</ImpositionType>
+        <TaxRuleId>510824</TaxRuleId>
         </Taxes>
         <TotalTax>1.52</TotalTax>
         </LineItem>
         </QuotationResponse>
-        <ApplicationData><ResponseTimeMS>10.2</ResponseTimeMS>
+        <ApplicationData><ResponseTimeMS>13.6</ResponseTimeMS>
         </ApplicationData>
         </VertexEnvelope></soapenv:Body></soapenv:Envelope>
     http_version: 
-  recorded_at: Mon, 26 Nov 2018 19:47:17 GMT
+  recorded_at: Thu, 29 Nov 2018 15:27:29 GMT
 recorded_with: VCR 4.0.0

--- a/test/payload_test.rb
+++ b/test/payload_test.rb
@@ -47,7 +47,9 @@ describe VertexClient::Payload do
           seller: {
             company: "CustomInk"
           },
-          :product=>"t-shirts",
+          :product=> {
+            :@productClass=>"53103000"
+          },
           :quantity=>7,
           :extended_price=>"35.50"
         },
@@ -56,16 +58,18 @@ describe VertexClient::Payload do
           :@taxDate=>"2018-11-14",
           :customer=> {
             :destination=> {
-              :street_address_1=>"1600 Pennsylvania Ave NW",
-              :city=>"Washington",
-              :main_division=>"DC",
-              :postal_code=>"20500"
+              :street_address_1=>"2910 District Ave #300",
+              :city=>"Fairfax",
+              :main_division=>"VA",
+              :postal_code=>"22031"
             }
           },
           :seller=> {
             :company=>"CustomInk"
           },
-          :product=>"t-shirts",
+          :product=> {
+            :@productClass=>"53103000"
+          },
           :quantity=>4,
           :extended_price=>"25.40"
         }

--- a/test/payload_test.rb
+++ b/test/payload_test.rb
@@ -48,7 +48,8 @@ describe VertexClient::Payload do
             company: "CustomInk"
           },
           :product=> {
-            :@productClass=>"53103000"
+            :@productClass=>"53103000",
+            content!: "4600"
           },
           :quantity=>7,
           :extended_price=>"35.50"
@@ -68,7 +69,8 @@ describe VertexClient::Payload do
             :company=>"CustomInk"
           },
           :product=> {
-            :@productClass=>"53103000"
+            :@productClass=>"53103000",
+            content!: "5300"
           },
           :quantity=>4,
           :extended_price=>"25.40"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -29,7 +29,6 @@ module TestInput
           document_number: 'test123',
           date: '2018-11-15',
           customer: {
-            code: "inky@customink.com",
             address_1: "11 Wall Street",
             city: "New York",
             state: "NY",
@@ -40,12 +39,12 @@ module TestInput
           },
           line_items: [
             {
-              product_code: "t-shirts",
+              product_code: "53103000",
               quantity: 7,
               price: "35.50",
             },
             {
-              product_code: "t-shirts",
+              product_code: "53103000",
               quantity: 4,
               price: "25.40",
               date: '2018-11-14',
@@ -53,11 +52,10 @@ module TestInput
                 company: "CustomInk"
               },
               customer: {
-                code: "prez@customink.com",
-                address_1: "1600 Pennsylvania Ave NW",
-                city: "Washington",
-                state: "DC",
-                postal_code: '20500'
+                address_1: "2910 District Ave #300",
+                city: "Fairfax",
+                state: "VA",
+                postal_code: '22031'
               }
             }
           ]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -39,12 +39,14 @@ module TestInput
           },
           line_items: [
             {
-              product_code: "53103000",
+              product_code: "4600",
+              product_class: "53103000",
               quantity: 7,
               price: "35.50",
             },
             {
-              product_code: "53103000",
+              product_code: "5300",
+              product_class: "53103000",
               quantity: 4,
               price: "25.40",
               date: '2018-11-14',


### PR DESCRIPTION
The original documentation showed product codes as a value of the `products` element in the payload, but upon further inspection, it seems like we are using product classes, which are an attribute on the product element. I will confirm this with Vertex before merging.