### PR TITLE
Creates line_items attributes on response

### DIFF
--- a/lib/vertex_client.rb
+++ b/lib/vertex_client.rb
@@ -12,6 +12,7 @@ module VertexClient
   autoload :InvoicePayload,       'vertex_client/invoice_payload'
   autoload :Payload,              'vertex_client/payload'
   autoload :Response,             'vertex_client/response'
+  autoload :ResponseLineItem,     'vertex_client/response_line_item'
   autoload :QuotationPayload,     'vertex_client/quotation_payload'
 
   class << self

--- a/lib/vertex_client/response.rb
+++ b/lib/vertex_client/response.rb
@@ -1,13 +1,24 @@
 module VertexClient
   class Response
 
-    attr_reader :body, :total_tax, :total, :subtotal
+    attr_reader :body, :total_tax, :total, :subtotal, :line_items
 
     def initialize(response, response_key)
-      @body      = response[:vertex_envelope][response_key].with_indifferent_access
-      @total_tax = BigDecimal.new(@body[:total_tax])
-      @total     = BigDecimal.new(@body[:total])
-      @subtotal  = BigDecimal.new(@body[:sub_total])
+      @body       = response[:vertex_envelope][response_key].with_indifferent_access
+      @total_tax  = BigDecimal.new(@body[:total_tax])
+      @total      = BigDecimal.new(@body[:total])
+      @subtotal   = BigDecimal.new(@body[:sub_total])
+      @line_items = create_line_items
+    end
+
+    private
+
+    def create_line_items
+      [].tap do |items|
+        [@body[:line_item]].flatten.each do |line_item|
+          items << ResponseLineItem.init_from_hash(line_item)
+        end
+      end
     end
   end
 end

--- a/lib/vertex_client/response_line_item.rb
+++ b/lib/vertex_client/response_line_item.rb
@@ -1,0 +1,24 @@
+module VertexClient
+  class ResponseLineItem
+
+    attr_reader :total_tax, :product_code, :raw, :quantity, :price
+
+    def initialize(params={})
+      @raw          = params[:raw]
+      @total_tax    = BigDecimal.new(params[:total_tax] || '0.0')
+      @product_code = params[:product_code]
+      @quantity     = params[:quantity]
+      @price        = params[:price]
+    end
+
+    def self.init_from_hash(line_item)
+      self.new(
+        raw:          line_item,
+        total_tax:    line_item[:total_tax],
+        product_code: line_item[:product],
+        quantity:     line_item[:quantity],
+        price:        line_item[:extended_price]
+      )
+    end
+  end
+end

--- a/lib/vertex_client/version.rb
+++ b/lib/vertex_client/version.rb
@@ -1,3 +1,3 @@
 module VertexClient
-  VERSION = "0.2.3"
+  VERSION = "0.2.4"
 end

--- a/test/response_line_item_test.rb
+++ b/test/response_line_item_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+describe VertexClient::ResponseLineItem do
+  let(:reponse_line_item) do
+    {
+      total_tax: '6.0',
+      product: '4600',
+      quantity: '1',
+      extended_price: '100'
+    }
+  end
+
+  it 'initializes from the response hash' do
+    item = VertexClient::ResponseLineItem.init_from_hash(reponse_line_item)
+    assert_equal BigDecimal.new('6.0'), item.total_tax
+    assert_equal reponse_line_item[:product], item.product_code
+    assert_equal reponse_line_item[:quantity], item.quantity
+    assert_equal reponse_line_item[:extended_price], item.price
+  end
+end

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -7,7 +7,11 @@ describe VertexClient::Response do
         quotation_response: {
           total_tax: '6.0',
           total: '106.0',
-          sub_total: '100.0'
+          sub_total: '100.0',
+          line_item: {
+            total_tax: '6.0',
+            product: '4600'
+          }
         }
       }},
       :quotation_response)
@@ -17,5 +21,6 @@ describe VertexClient::Response do
     assert_equal @response.total_tax, BigDecimal.new('6.0')
     assert_equal @response.total, BigDecimal.new('106.0')
     assert_equal @response.subtotal, BigDecimal.new('100.0')
+    assert_kind_of VertexClient::ResponseLineItem, @response.line_items.first
   end
 end


### PR DESCRIPTION
These changes create a `line_items` attribute on the `response` object, which is an array of `ResponseLineItem` objects. Each `ResponseLineItem` has `:total_tax, :product_code, :raw, :quantity, :price` attributes. The `raw` attribute contains the raw json (converted from xml) line item from vertex.