### PR TITLE
Allow either/or of state and postal code

### DIFF
--- a/lib/vertex_client/payload_validator.rb
+++ b/lib/vertex_client/payload_validator.rb
@@ -28,7 +28,7 @@ module VertexClient
     end
 
     def state_or_postal_code?(customer)
-      customer[:state].present? && customer[:postal_code].present?
+      customer[:state].present? || customer[:postal_code].present?
     end
 
     def document_number_missing?

--- a/test/payload_validator_test.rb
+++ b/test/payload_validator_test.rb
@@ -13,6 +13,20 @@ describe VertexClient::PayloadValidator do
     end
   end
 
+  it 'allows just a state' do
+    payload = working_quote_params
+    payload[:customer].delete(:postal_code)
+    payload = VertexClient::QuotationPayload.new(payload)
+    VertexClient::PayloadValidator.new(payload, [:location]).validate!
+  end
+
+  it 'allows just a postal code' do
+    payload = working_quote_params
+    payload[:customer].delete(:state)
+    payload = VertexClient::QuotationPayload.new(payload)
+    VertexClient::PayloadValidator.new(payload, [:location]).validate!
+  end
+
   it 'raises if the document_number is not included' do
     payload = working_quote_params
     payload.delete(:document_number)


### PR DESCRIPTION
This loosens the location validation to pass if either state or postal code is provided. If that's not the intended behavior feel free to close, but I noticed that the method's behavior is not aligned with its name and wondered if there was a logical inversion here.