### PR TITLE
Penny precise allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,18 @@ VertexClient.distribute_tax(
 )
 ```
 
+### Adjustment Allocator
+
+Allocates a given monetary adjustment, such as a service charge or a discount, across a given array of weights, such as line items. The `adjustment` parameter must be passed in as a positive or negative numeric dollar amount, such as `-0.56`, `7.00` or `12.34`, and the `weights` parameter must be passed in as an array of non-negative numeric values, such as `[1.23, 4.56, 7.89]` or `[1, 2, 3, 4]`, which can represent prices or ratios.
+
+```ruby
+VertexClient::Utils::AdjustmentAllocator.new(1234.56, [310.00, 350.00, 200.00, 140.00]).allocate
+#=> [#<BigDecimal:7fa6bba053c0,'0.38271E3',18(36)>,
+     #<BigDecimal:7fa6bba0fcd0,'0.4321E3',18(36)>,
+     #<BigDecimal:7fa6bba0dfc0,'0.24691E3',18(36)>,
+     #<BigDecimal:7fa6bba17b88,'0.17284E3',18(36)>]
+```
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/lib/vertex_client.rb
+++ b/lib/vertex_client.rb
@@ -5,6 +5,9 @@ require 'active_support/all'
 require 'savon'
 
 module VertexClient
+  module Utils
+    autoload :AdjustmentAllocator, 'vertex_client/utils/adjustment_allocator'
+  end
 
   autoload :Configuration,        'vertex_client/configuration'
   autoload :Connection,           'vertex_client/connection'
@@ -59,5 +62,5 @@ module VertexClient
   class Error < StandardError; end
   class PayloadValidationError < Error; end
   class RemoteServerError < Error; end
-
+  class UtilsValidationError < Error; end
 end

--- a/lib/vertex_client/utils/adjustment_allocator.rb
+++ b/lib/vertex_client/utils/adjustment_allocator.rb
@@ -1,0 +1,60 @@
+module VertexClient
+  module Utils
+    class AdjustmentAllocator
+      def initialize(adjustment, weights)
+        @adjustment = adjustment
+        @weights    = weights
+      end
+
+      def allocate
+        validate!
+        allocations, remainders = allocations_with_remainders.transpose
+        remaining_adjustment    = adjustment_in_cents - allocations.sum
+        deserving_indices       = remainders.each_with_index.sort_by { |remainder, i| [remainder, i] }.map { |_r, i| i }.last(remaining_adjustment)
+        allocations.each_with_index.map { |allocation, i| deserving_indices.include?(i) ? cents_to_dollars(allocation + 1) : cents_to_dollars(allocation) }
+      end
+
+      private
+
+      ADJUSTMENT_ERROR = 'adjustment must be formatted as a dollar amount with two decimal places (eg: 2.14 or 0.05)'.freeze
+      WEIGHTS_ERROR    = 'all weights must be a non-negative integer or float, and must not total zero'.freeze
+
+      def adjustment_format_valid?
+        adjustment.is_a?(Numeric) && /^-?\d+\.\d{2}$/.match(adjustment.to_s)
+      end
+
+      def adjustment_in_cents
+        dollars_to_cents(adjustment)
+      end
+
+      def allocations_with_remainders
+        weights.map do |weight|
+          (adjustment_in_cents * weight).divmod(weights_total)
+        end
+      end
+
+      def cents_to_dollars(cents)
+        cents / 100.to_d
+      end
+
+      def dollars_to_cents(dollars)
+        (dollars * 100).to_i
+      end
+
+      def validate!
+        raise VertexClient::UtilsValidationError.new(ADJUSTMENT_ERROR) unless adjustment_format_valid?
+        raise VertexClient::UtilsValidationError.new(WEIGHTS_ERROR) unless weights_format_valid?
+      end
+
+      def weights_format_valid?
+        weights.all? { |weight| weight.is_a?(Numeric) && weight >= 0 && /^\d+(?:\.\d+)?$/.match(weight.to_s) } && !weights_total.zero?
+      end
+
+      def weights_total
+        weights.sum
+      end
+
+      attr_reader :adjustment, :weights
+    end
+  end
+end

--- a/test/utils/adjustment_allocator_test.rb
+++ b/test/utils/adjustment_allocator_test.rb
@@ -1,0 +1,66 @@
+require 'test_helper'
+
+describe VertexClient::Utils::AdjustmentAllocator do
+  let(:adjustment)          { 1234.56 }
+  let(:weights_as_prices)   { [310.00, 350.00, 200.00, 140.00] }
+  let(:weights_as_ratios)   { [31, 35, 20, 14] }
+  let(:expected_allocation) { [382.71.to_d, 432.10.to_d, 246.91.to_d, 172.84.to_d] }
+
+  describe '#allocate' do
+    describe 'adjustment validation' do
+      it 'raises if adjustment is a string' do
+        assert_raises VertexClient::UtilsValidationError do
+          VertexClient::Utils::AdjustmentAllocator.new(adjustment.to_s, weights_as_prices).allocate
+        end
+      end
+
+      it 'raises if adjustment is an integer' do
+        assert_raises VertexClient::UtilsValidationError do
+          VertexClient::Utils::AdjustmentAllocator.new(adjustment.to_i, weights_as_prices).allocate
+        end
+      end
+
+      it 'raises if adjustment has more than two decimal places' do
+        assert_raises VertexClient::UtilsValidationError do
+          VertexClient::Utils::AdjustmentAllocator.new(1234.56789, weights_as_prices).allocate
+        end
+      end
+    end
+
+    describe 'weights validation' do
+      it 'raises if any of the weights is negative' do
+        assert_raises VertexClient::UtilsValidationError do
+          VertexClient::Utils::AdjustmentAllocator.new(adjustment, [-1.0, 2.0, 3.0]).allocate
+        end
+      end
+
+      it 'raises if the weights total to zero' do
+        assert_raises VertexClient::UtilsValidationError do
+          VertexClient::Utils::AdjustmentAllocator.new(adjustment, [0, 0, 0]).allocate
+        end
+      end
+
+      it 'raises if any of the weights is a string' do
+        assert_raises VertexClient::UtilsValidationError do
+          VertexClient::Utils::AdjustmentAllocator.new(adjustment, [1.0, 2.0, '3']).allocate
+        end
+      end
+    end
+    
+    it 'properly allocates a postive adjustment (ie: service charge)' do
+      assert_equal expected_allocation, VertexClient::Utils::AdjustmentAllocator.new(adjustment, weights_as_prices).allocate
+    end
+
+    it 'properly allocates a negative adjustment (ie: discount)' do
+      discount            = adjustment * -1
+      discount_allocation = expected_allocation.map { |weight| weight * -1 }
+      assert_equal discount_allocation, VertexClient::Utils::AdjustmentAllocator.new(discount, weights_as_prices).allocate
+    end
+
+    it 'properly allocates an adjustment regardless of whether weights are given as prices or as ratios' do
+      price_allocation = VertexClient::Utils::AdjustmentAllocator.new(adjustment, weights_as_prices).allocate
+      ratio_allocation = VertexClient::Utils::AdjustmentAllocator.new(adjustment, weights_as_ratios).allocate
+      assert_equal price_allocation, ratio_allocation
+    end
+  end
+end


### PR DESCRIPTION
This adds `VertexClient::Utils::AdjustmentAllocator#allocate` to the gem, to use for things like discounts and service charges. Should be applicable for [this PR](https://github.com/customink/rails_frontend/pull/3392) and [this ticket](https://customink.atlassian.net/secure/RapidBoard.jspa?rapidView=143&modal=detail&selectedIssue=YC-390).

Derives from this [Betterment blog post](https://betterment.engineering/a-functional-approach-to-penny-precise-allocation-55e2a74a964e).

<img width="947" alt="screen shot 2018-12-10 at 2 07 04 pm" src="https://user-images.githubusercontent.com/7169748/49754967-8eb6e180-fc85-11e8-9746-be74ca58a776.png">
