### PR TITLE
Consolidate errors and shorten names

### DIFF
--- a/.byebug_history
+++ b/.byebug_history
@@ -1,4 +1,0 @@
-continue
-payload
-continue
-payload

--- a/.byebug_history
+++ b/.byebug_history
@@ -1,0 +1,4 @@
+continue
+payload
+continue
+payload

--- a/lib/vertex_client.rb
+++ b/lib/vertex_client.rb
@@ -60,7 +60,6 @@ module VertexClient
   end
 
   class Error < StandardError; end
-  class PayloadValidationError < Error; end
-  class RemoteServerError < Error; end
-  class UtilsValidationError < Error; end
+  class ValidationError < Error; end
+  class ServerError < Error; end
 end

--- a/lib/vertex_client/connection.rb
+++ b/lib/vertex_client/connection.rb
@@ -34,7 +34,7 @@ module VertexClient
       elsif @payload.quotation?
         FallbackResponse.new(@payload)
       else
-        raise RemoteServerError.new(ERROR_MESSAGE)
+        raise ServerError.new(ERROR_MESSAGE)
       end
     end
 

--- a/lib/vertex_client/payload_validator.rb
+++ b/lib/vertex_client/payload_validator.rb
@@ -15,12 +15,12 @@ module VertexClient
     private
 
     def location
-      raise VertexClient::PayloadValidationError.new('customer requires a state or postal_code') if customer_missing_location?
+      raise VertexClient::ValidationError.new('customer requires a state or postal_code') if customer_missing_location?
     end
 
     def document_number
-      raise VertexClient::PayloadValidationError.new('document_number is required for invoice') if document_number_missing?
-      raise VertexClient::PayloadValidationError.new("document_number must be less than or equal to #{DOCUMENT_NUMBER_LIMIT} characters") if document_number_too_long?
+      raise VertexClient::ValidationError.new('document_number is required for invoice') if document_number_missing?
+      raise VertexClient::ValidationError.new("document_number must be less than or equal to #{DOCUMENT_NUMBER_LIMIT} characters") if document_number_too_long?
     end
 
     def customer_missing_location?

--- a/lib/vertex_client/utils/adjustment_allocator.rb
+++ b/lib/vertex_client/utils/adjustment_allocator.rb
@@ -42,8 +42,8 @@ module VertexClient
       end
 
       def validate!
-        raise VertexClient::UtilsValidationError.new(ADJUSTMENT_ERROR) unless adjustment_format_valid?
-        raise VertexClient::UtilsValidationError.new(WEIGHTS_ERROR) unless weights_format_valid?
+        raise VertexClient::ValidationError.new(ADJUSTMENT_ERROR) unless adjustment_format_valid?
+        raise VertexClient::ValidationError.new(WEIGHTS_ERROR) unless weights_format_valid?
       end
 
       def weights_format_valid?

--- a/lib/vertex_client/version.rb
+++ b/lib/vertex_client/version.rb
@@ -1,3 +1,3 @@
 module VertexClient
-  VERSION = "0.2.5"
+  VERSION = "0.3.0"
 end

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -172,7 +172,7 @@ describe VertexClient::Connection do
   it 'raises if the circuit is open on invoice' do
     VertexClient.configuration.circuit_config = {}
     VertexClient.circuit.send(:open!)
-    assert_raises VertexClient::RemoteServerError do
+    assert_raises VertexClient::ServerError do
       VertexClient.invoice(working_quote_params)
     end
   end
@@ -184,7 +184,7 @@ describe VertexClient::Connection do
       VertexClient::InvoicePayload.new(working_quote_params))
     raises_expection = -> { raise Savon::Error.new('something went wrong') }
     connection.stub :client, raises_expection do
-      assert_raises VertexClient::RemoteServerError do
+      assert_raises VertexClient::ServerError do
         connection.request
       end
     end
@@ -196,7 +196,7 @@ describe VertexClient::Connection do
       VertexClient::InvoicePayload.new(working_quote_params))
     raises_expection = -> { raise Savon::Error.new('something went wrong') }
     connection.stub :client, raises_expection do
-      assert_raises VertexClient::RemoteServerError do
+      assert_raises VertexClient::ServerError do
         connection.request
       end
     end

--- a/test/payload_test.rb
+++ b/test/payload_test.rb
@@ -14,7 +14,7 @@ describe VertexClient::Payload do
   end
 
   it 'raises if the document_number is not included for invoice' do
-    assert_raises VertexClient::PayloadValidationError do
+    assert_raises VertexClient::ValidationError do
       input = working_quote_params
       input.delete(:document_number)
       VertexClient::InvoicePayload.new(input).transform
@@ -31,7 +31,7 @@ describe VertexClient::Payload do
     params = working_quote_params
     params[:customer].delete(:postal_code)
     params[:customer].delete(:state)
-    assert_raises VertexClient::PayloadValidationError do
+    assert_raises VertexClient::ValidationError do
       VertexClient::QuotationPayload.new(params).transform
     end
   end

--- a/test/payload_validator_test.rb
+++ b/test/payload_validator_test.rb
@@ -8,7 +8,7 @@ describe VertexClient::PayloadValidator do
     payload[:customer].delete(:postal_code)
     payload[:customer].delete(:state)
     payload = VertexClient::QuotationPayload.new(payload)
-    assert_raises VertexClient::PayloadValidationError do
+    assert_raises VertexClient::ValidationError do
       VertexClient::PayloadValidator.new(payload, [:location]).validate!
     end
   end
@@ -17,7 +17,7 @@ describe VertexClient::PayloadValidator do
     payload = working_quote_params
     payload.delete(:document_number)
     payload = VertexClient::QuotationPayload.new(payload)
-    assert_raises VertexClient::PayloadValidationError do
+    assert_raises VertexClient::ValidationError do
       VertexClient::PayloadValidator.new(payload, [:document_number]).validate!
     end
   end
@@ -26,7 +26,7 @@ describe VertexClient::PayloadValidator do
     payload = working_quote_params
     payload[:document_number] = 'a-document-number-that-is-too-many-characters'
     payload = VertexClient::QuotationPayload.new(payload)
-    assert_raises VertexClient::PayloadValidationError do
+    assert_raises VertexClient::ValidationError do
       VertexClient::PayloadValidator.new(payload, [:document_number]).validate!
     end
   end

--- a/test/utils/adjustment_allocator_test.rb
+++ b/test/utils/adjustment_allocator_test.rb
@@ -9,19 +9,19 @@ describe VertexClient::Utils::AdjustmentAllocator do
   describe '#allocate' do
     describe 'adjustment validation' do
       it 'raises if adjustment is a string' do
-        assert_raises VertexClient::UtilsValidationError do
+        assert_raises VertexClient::ValidationError do
           VertexClient::Utils::AdjustmentAllocator.new(adjustment.to_s, weights_as_prices).allocate
         end
       end
 
       it 'raises if adjustment is an integer' do
-        assert_raises VertexClient::UtilsValidationError do
+        assert_raises VertexClient::ValidationError do
           VertexClient::Utils::AdjustmentAllocator.new(adjustment.to_i, weights_as_prices).allocate
         end
       end
 
       it 'raises if adjustment has more than two decimal places' do
-        assert_raises VertexClient::UtilsValidationError do
+        assert_raises VertexClient::ValidationError do
           VertexClient::Utils::AdjustmentAllocator.new(1234.56789, weights_as_prices).allocate
         end
       end
@@ -29,24 +29,24 @@ describe VertexClient::Utils::AdjustmentAllocator do
 
     describe 'weights validation' do
       it 'raises if any of the weights is negative' do
-        assert_raises VertexClient::UtilsValidationError do
+        assert_raises VertexClient::ValidationError do
           VertexClient::Utils::AdjustmentAllocator.new(adjustment, [-1.0, 2.0, 3.0]).allocate
         end
       end
 
       it 'raises if the weights total to zero' do
-        assert_raises VertexClient::UtilsValidationError do
+        assert_raises VertexClient::ValidationError do
           VertexClient::Utils::AdjustmentAllocator.new(adjustment, [0, 0, 0]).allocate
         end
       end
 
       it 'raises if any of the weights is a string' do
-        assert_raises VertexClient::UtilsValidationError do
+        assert_raises VertexClient::ValidationError do
           VertexClient::Utils::AdjustmentAllocator.new(adjustment, [1.0, 2.0, '3']).allocate
         end
       end
     end
-    
+
     it 'properly allocates a postive adjustment (ie: service charge)' do
       assert_equal expected_allocation, VertexClient::Utils::AdjustmentAllocator.new(adjustment, weights_as_prices).allocate
     end


### PR DESCRIPTION
This PR merges `VertexClient::PayloadValidationError` and `VertexClient::UtilsValidationError` together into `VertexClient::ValidationError`, and renames `VertexClient::RemoteServerError` to `VertexClient::ServerError` since remote is slightly redundant.

When you update, you'll need to revisit any exceptions you are rescuing, and also your circuitbox configuration to opt into the correct trigger exceptions.