### PR TITLE
Add country code to vertex payloads

### DIFF
--- a/lib/vertex_client/payload.rb
+++ b/lib/vertex_client/payload.rb
@@ -84,7 +84,8 @@ module VertexClient
           street_address_2: customer[:address_2],
           city:             customer[:city],
           main_division:    customer[:state],
-          postal_code:      customer[:postal_code]
+          postal_code:      customer[:postal_code],
+          country:          customer[:country]
         })
       })
     end

--- a/test/payload_test.rb
+++ b/test/payload_test.rb
@@ -52,7 +52,8 @@ describe VertexClient::Payload do
               :street_address_1=>"11 Wall Street",
               :city=>"New York",
               :main_division=>"NY",
-              :postal_code=>"10005"
+              :postal_code=>"10005",
+              :country=>"US"
             }
           },
           seller: {
@@ -73,7 +74,8 @@ describe VertexClient::Payload do
               :street_address_1=>"2910 District Ave #300",
               :city=>"Fairfax",
               :main_division=>"VA",
-              :postal_code=>"22031"
+              :postal_code=>"22031",
+              :country=>"US"
             }
           },
           :seller=> {

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -33,7 +33,8 @@ module TestInput
             address_1: "11 Wall Street",
             city: "New York",
             state: "NY",
-            postal_code: '10005'
+            postal_code: '10005',
+            country: 'US'
           },
           seller: {
             company: "CustomInk"
@@ -58,7 +59,8 @@ module TestInput
                 address_1: "2910 District Ave #300",
                 city: "Fairfax",
                 state: "VA",
-                postal_code: '22031'
+                postal_code: '22031',
+                country: 'US'
               }
             }
           ]


### PR DESCRIPTION
Canadian postal codes will always lead to a SOAPFault in production unless a country code is supplied as part of the payload to vertex. This pulls country in to the xml we send.