### PR TITLE
Update Allocator to be more flexible with inputs

### DIFF
--- a/lib/vertex_client/utils/adjustment_allocator.rb
+++ b/lib/vertex_client/utils/adjustment_allocator.rb
@@ -7,6 +7,7 @@ module VertexClient
       end
 
       def allocate
+        return [] if weights.empty? && @adjustment.zero?
         validate!
         allocations, remainders = allocations_with_remainders.transpose
         remaining_adjustment    = adjustment_in_cents - allocations.sum

--- a/lib/vertex_client/utils/adjustment_allocator.rb
+++ b/lib/vertex_client/utils/adjustment_allocator.rb
@@ -17,7 +17,7 @@ module VertexClient
       private
 
       ADJUSTMENT_ERROR = 'adjustment must not be more precise than two decimal places (eg: 2.14 or 0.05)'.freeze
-      WEIGHTS_ERROR    = 'all weights must be a non-negative integer or float, and must not total zero'.freeze
+      WEIGHTS_ERROR    = 'all weights must be a non-negative number, and must not total zero'.freeze
 
       def adjustment_format_valid?
         adjustment.is_a?(Numeric) && (dollars_to_cents(adjustment) == adjustment * 100)
@@ -47,7 +47,7 @@ module VertexClient
       end
 
       def weights_format_valid?
-        weights.all? { |weight| weight.is_a?(Numeric) && weight >= 0 && /^\d+(?:\.\d+)?$/.match(weight.to_s) } && !weights_total.zero?
+        weights.all? { |weight| weight.is_a?(Numeric) && weight >= 0 } && !weights_total.zero?
       end
 
       def weights_total

--- a/lib/vertex_client/utils/adjustment_allocator.rb
+++ b/lib/vertex_client/utils/adjustment_allocator.rb
@@ -16,11 +16,11 @@ module VertexClient
 
       private
 
-      ADJUSTMENT_ERROR = 'adjustment must be formatted as a dollar amount with two decimal places (eg: 2.14 or 0.05)'.freeze
+      ADJUSTMENT_ERROR = 'adjustment must not be more precise than two decimal places (eg: 2.14 or 0.05)'.freeze
       WEIGHTS_ERROR    = 'all weights must be a non-negative integer or float, and must not total zero'.freeze
 
       def adjustment_format_valid?
-        adjustment.is_a?(Numeric) && /^-?\d+\.\d{1,2}$/.match(adjustment.to_s)
+        adjustment.is_a?(Numeric) && (dollars_to_cents(adjustment) == adjustment * 100)
       end
 
       def adjustment_in_cents

--- a/test/utils/adjustment_allocator_test.rb
+++ b/test/utils/adjustment_allocator_test.rb
@@ -14,10 +14,6 @@ describe VertexClient::Utils::AdjustmentAllocator do
         end
       end
 
-      it 'allows an integer adjustment' do
-        assert_equal [0, 0, 0, 0], VertexClient::Utils::AdjustmentAllocator.new(0, weights_as_prices).allocate
-      end
-
       it 'raises if adjustment has more than two decimal places' do
         assert_raises VertexClient::ValidationError do
           VertexClient::Utils::AdjustmentAllocator.new(1234.56789, weights_as_prices).allocate

--- a/test/utils/adjustment_allocator_test.rb
+++ b/test/utils/adjustment_allocator_test.rb
@@ -14,10 +14,8 @@ describe VertexClient::Utils::AdjustmentAllocator do
         end
       end
 
-      it 'raises if adjustment is an integer' do
-        assert_raises VertexClient::ValidationError do
-          VertexClient::Utils::AdjustmentAllocator.new(adjustment.to_i, weights_as_prices).allocate
-        end
+      it 'allows an integer adjustment' do
+        assert_equal [0, 0, 0, 0], VertexClient::Utils::AdjustmentAllocator.new(0, weights_as_prices).allocate
       end
 
       it 'raises if adjustment has more than two decimal places' do

--- a/test/utils/adjustment_allocator_test.rb
+++ b/test/utils/adjustment_allocator_test.rb
@@ -60,5 +60,32 @@ describe VertexClient::Utils::AdjustmentAllocator do
     it "handles an empty array of weights if the adjustment amount is 0" do
       assert_equal [], VertexClient::Utils::AdjustmentAllocator.new(0, []).allocate
     end
+
+    describe "allocating remainder pennies perfectly" do
+      let(:one_penny)           { '0.01'.to_d }
+      let(:two_pennies)         { '0.02'.to_d }
+      let(:three_pennies)       { '0.03'.to_d }
+
+      # on first pass, each one gets 0 pennies and has a remainder of $0.006.
+      # 5-way tie on the remainder, so the last three will each get one
+      it "assigns remainder pennies, breaking ties by going with the last" do
+        expected = [0, 0, one_penny, one_penny, one_penny]
+        assert_equal expected, VertexClient::Utils::AdjustmentAllocator.new(three_pennies, [1.0, 1.0, 1.0, 1.0, 1.0]).allocate
+      end
+
+      # 2.0 weight wins for the first remainder penny.
+      # Then, after 3-way second place tie for $0.004, the last one gets the penny
+      it "assigns remainder pennies, breaking second place ties" do
+       expected = [0, 0, one_penny, one_penny]
+       assert_equal expected, VertexClient::Utils::AdjustmentAllocator.new(two_pennies, [1.0, 1.0, 2.0, 1.0]).allocate
+      end
+
+      # 6.0 gets a penny outright. Then all have remainder of $0.002
+      # To break tie, we give the extra penny to the last.
+      it "assigns remainder pennies, regardless of pennies already assigned" do
+        expected = [0, 0, 0, 0, two_pennies]
+        assert_equal expected, VertexClient::Utils::AdjustmentAllocator.new(two_pennies, [1.0, 1.0, 1.0, 1.0, 6.0]).allocate
+      end
+    end
   end
 end

--- a/test/utils/adjustment_allocator_test.rb
+++ b/test/utils/adjustment_allocator_test.rb
@@ -1,10 +1,10 @@
 require 'test_helper'
 
 describe VertexClient::Utils::AdjustmentAllocator do
-  let(:adjustment)          { 1234.56 }
-  let(:weights_as_prices)   { [310.00, 350.00, 200.00, 140.00] }
+  let(:adjustment)          { '1234.56'.to_d }
+  let(:weights_as_prices)   { ['310'.to_d, '350'.to_d, '200'.to_d, '140'.to_d] }
   let(:weights_as_ratios)   { [31, 35, 20, 14] }
-  let(:expected_allocation) { [382.71.to_d, 432.10.to_d, 246.91.to_d, 172.84.to_d] }
+  let(:expected_allocation) { ['382.71'.to_d, '432.1'.to_d, '246.91'.to_d, '172.84'.to_d] }
 
   describe '#allocate' do
     describe 'adjustment validation' do
@@ -16,7 +16,7 @@ describe VertexClient::Utils::AdjustmentAllocator do
 
       it 'raises if adjustment has more than two decimal places' do
         assert_raises VertexClient::ValidationError do
-          VertexClient::Utils::AdjustmentAllocator.new(1234.56789, weights_as_prices).allocate
+          VertexClient::Utils::AdjustmentAllocator.new('1234.567'.to_d, weights_as_prices).allocate
         end
       end
     end

--- a/test/utils/adjustment_allocator_test.rb
+++ b/test/utils/adjustment_allocator_test.rb
@@ -56,5 +56,9 @@ describe VertexClient::Utils::AdjustmentAllocator do
       ratio_allocation = VertexClient::Utils::AdjustmentAllocator.new(adjustment, weights_as_ratios).allocate
       assert_equal price_allocation, ratio_allocation
     end
+
+    it "handles an empty array of weights if the adjustment amount is 0" do
+      assert_equal [], VertexClient::Utils::AdjustmentAllocator.new(0, []).allocate
+    end
   end
 end


### PR DESCRIPTION
With these updates, I'll be able to switch RFE over from its `AdjustmentProrater` to using VertexClient's `AdjustmentAllocator`.

The commit for `handle empty array of weights if adjustment is 0` helps us handle RFE test cases for orders with no order items.

@a-maas this change should allow you to remove the `|| zero_to_d` workarounds from RBE's `OrderTaxer`.