### PR TITLE
Add Support for TaxAreaLookup

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
 VERTEX_TRUSTED_ID=secret
-VERTEX_SOAP_API=https://connect.vertexsmb.com/vertex-ws/services/CalculateTax70
+VERTEX_SOAP_API=https://connect.vertexsmb.com/vertex-ws/services/

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ The following environment variables are used to configure the client.
 
 ```
 VERTEX_TRUSTED_ID=your-trusted-id
-VERTEX_SOAP_API=https://connect.vertexsmb.com/vertex-ws/services/CalculateTax70
+VERTEX_SOAP_API=https://connect.vertexsmb.com/vertex-ws/services/
 ```
 ### Initializer
 

--- a/lib/vertex_client.rb
+++ b/lib/vertex_client.rb
@@ -20,6 +20,9 @@ module VertexClient
   autoload :Response,             'vertex_client/response'
   autoload :ResponseLineItem,     'vertex_client/response_line_item'
   autoload :QuotationPayload,     'vertex_client/quotation_payload'
+  autoload :TaxAreaPayload,       'vertex_client/tax_area_payload'
+  autoload :TaxAreaResponse,      'vertex_client/tax_area_response'
+
 
   class << self
 
@@ -48,6 +51,10 @@ module VertexClient
 
     def distribute_tax(payload)
       Connection.new(DistributeTaxPayload.new(payload)).request
+    end
+
+    def tax_area(payload)
+      Connection.new(TaxAreaPayload.new(payload)).request
     end
 
     def circuit

--- a/lib/vertex_client/connection.rb
+++ b/lib/vertex_client/connection.rb
@@ -60,9 +60,13 @@ module VertexClient
       @config ||= VertexClient.configuration
     end
 
+    def url
+      URI.join config.soap_api, @payload.endpoint
+    end
+
     def client
       @client ||= Savon.client do |globals|
-        globals.endpoint config.soap_api
+        globals.endpoint url
         globals.namespace VERTEX_NAMESPACE
         globals.convert_request_keys_to :camelcase
         globals.env_namespace :soapenv

--- a/lib/vertex_client/connection.rb
+++ b/lib/vertex_client/connection.rb
@@ -30,6 +30,7 @@ module VertexClient
     # TODO Consider removing this conditional to make this more robust
     def handle_response(response)
       if response
+        return TaxAreaResponse.new(response, @payload.response_key) if @payload.is_a? TaxAreaPayload
         Response.new(response.body, @payload.response_key)
       elsif @payload.quotation?
         FallbackResponse.new(@payload)

--- a/lib/vertex_client/connection.rb
+++ b/lib/vertex_client/connection.rb
@@ -30,9 +30,9 @@ module VertexClient
     # TODO Consider removing this conditional to make this more robust
     def handle_response(response)
       if response
-        return TaxAreaResponse.new(response, @payload.response_key) if @payload.is_a? TaxAreaPayload
+        return TaxAreaResponse.new(response, @payload.response_key) if @payload.is_a?(TaxAreaPayload)
         Response.new(response.body, @payload.response_key)
-      elsif @payload.quotation?
+      elsif @payload.quotation? || @payload.is_a?(TaxAreaPayload)
         FallbackResponse.new(@payload)
       else
         raise ServerError.new(ERROR_MESSAGE)

--- a/lib/vertex_client/fallback_response.rb
+++ b/lib/vertex_client/fallback_response.rb
@@ -4,6 +4,9 @@ module VertexClient
 
     attr_reader :body, :total_tax, :total, :subtotal, :line_items
 
+    # Temporary hack for tax_area_lookup
+    attr_reader :tax_area_id
+
     def initialize(payload)
       @payload = payload.transform
       @body = @payload.output

--- a/lib/vertex_client/payload.rb
+++ b/lib/vertex_client/payload.rb
@@ -90,7 +90,8 @@ module VertexClient
           city:             customer[:city],
           main_division:    customer[:state],
           postal_code:      customer[:postal_code],
-          country:          customer[:country]
+          country:          customer[:country],
+          tax_area_id:      customer[:tax_area_id]
         })
       })
     end

--- a/lib/vertex_client/payload.rb
+++ b/lib/vertex_client/payload.rb
@@ -1,6 +1,7 @@
 module VertexClient
   class Payload
 
+    ENDPOINT = 'CalculateTax70'.freeze
     SALE = 'SALE'.freeze
     VALIDATIONS = [:location].freeze
 
@@ -37,6 +38,10 @@ module VertexClient
 
     def quotation?
       payload_name == QuotationPayload::NAME
+    end
+
+    def endpoint
+      self.class::ENDPOINT
     end
 
     private

--- a/lib/vertex_client/tax_area_payload.rb
+++ b/lib/vertex_client/tax_area_payload.rb
@@ -1,0 +1,18 @@
+module VertexClient
+  class TaxAreaPayload < Payload
+    ENDPOINT = 'LookupTaxAreas70'.freeze
+    NAME = 'tax_area'.freeze
+
+    def transform
+      self
+    end
+
+    def output
+      {
+        tax_area_lookup: {
+          postal_address: transform_customer(@input)[:destination]
+        }
+      }
+    end
+  end
+end

--- a/lib/vertex_client/tax_area_response.rb
+++ b/lib/vertex_client/tax_area_response.rb
@@ -1,0 +1,11 @@
+module VertexClient
+  class TaxAreaResponse
+
+    attr_reader :body, :tax_area_id
+
+    def initialize(response, response_key)
+      @body = response.body[:vertex_envelope][response_key].with_indifferent_access
+      @tax_area_id = response.body[:vertex_envelope][response_key][:tax_area_result][:@tax_area_id]
+    end
+  end
+end

--- a/lib/vertex_client/version.rb
+++ b/lib/vertex_client/version.rb
@@ -1,3 +1,3 @@
 module VertexClient
-  VERSION = "0.3.1"
+  VERSION = "0.4.0"
 end

--- a/test/cassettes/tax_area.yml
+++ b/test/cassettes/tax_area.yml
@@ -1,0 +1,68 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "{VERTEX_SOAP_API}LookupTaxAreas70"
+    body:
+      encoding: UTF-8
+      string: '<?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:urn="urn:vertexinc:o-series:tps:7:0"
+        xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"><soapenv:Body><urn:VertexEnvelope><Login><TrustedId>{VERTEX_TRUSTED_ID}</TrustedId></Login><TaxAreaRequest><TaxAreaLookup><PostalAddress><StreetAddress1>2910
+        District Ave #300</StreetAddress1><City>Fairfax</City><MainDivision>VA</MainDivision><PostalCode>22031</PostalCode></PostalAddress></TaxAreaLookup></TaxAreaRequest></urn:VertexEnvelope></soapenv:Body></soapenv:Envelope>'
+    headers:
+      Soapaction:
+      - '"VertexEnvelope"'
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Content-Length:
+      - '630'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 11 Jan 2019 16:19:47 GMT
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      Soapaction:
+      - '""'
+      Server:
+      - ''
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"><soapenv:Header></soapenv:Header><soapenv:Body><VertexEnvelope xmlns="urn:vertexinc:o-series:tps:7:0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Login><TrustedId></TrustedId>
+        </Login>
+        <TaxAreaResponse><TaxAreaResult taxAreaId="470590000" confidenceIndicator="100"><Jurisdiction jurisdictionLevel="COUNTRY" effectiveDate="1900-01-01" expirationDate="9999-12-31" jurisdictionId="1">UNITED STATES</Jurisdiction>
+        <Jurisdiction jurisdictionLevel="STATE" effectiveDate="1900-01-01" expirationDate="9999-12-31" jurisdictionId="39067">VIRGINIA</Jurisdiction>
+        <Jurisdiction jurisdictionLevel="COUNTY" effectiveDate="1900-01-01" expirationDate="9999-12-31" jurisdictionId="39378">FAIRFAX</Jurisdiction>
+        <Jurisdiction jurisdictionLevel="DISTRICT" effectiveDate="2013-07-01" expirationDate="9999-12-31" jurisdictionId="97100">REGIONAL TRANSPORTATION DISTRICT</Jurisdiction>
+        <PostalAddress><StreetAddress1>2910 District Ave Ste 300</StreetAddress1>
+        <City>Fairfax</City>
+        <MainDivision>VA</MainDivision>
+        <SubDivision>Fairfax</SubDivision>
+        <PostalCode>22031-2284</PostalCode>
+        <Country>USA</Country>
+        </PostalAddress>
+        <Status lookupResult="NORMAL"></Status>
+        </TaxAreaResult>
+        </TaxAreaResponse>
+        <ApplicationData><ResponseTimeMS>27.8</ResponseTimeMS>
+        </ApplicationData>
+        </VertexEnvelope></soapenv:Body></soapenv:Envelope>
+    http_version: 
+  recorded_at: Fri, 11 Jan 2019 16:19:47 GMT
+recorded_with: VCR 4.0.0

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -42,6 +42,18 @@ describe VertexClient::Connection do
     end
   end
 
+  it 'does tax_area' do
+    params = {
+      address_1: "2910 District Ave #300",
+      city: "Fairfax",
+      state: "VA",
+      postal_code: "22031"
+    }
+    VCR.use_cassette("tax_area", :match_requests_on => []) do
+      assert_equal "470590000", VertexClient.tax_area(params).tax_area_id
+    end
+  end
+
   it 'uses circuit if it is available' do
     VertexClient.configuration.circuit_config = {}
     VCR.use_cassette("quotation", :match_requests_on => []) do


### PR DESCRIPTION
In order to improve performance with quotation and invoice we have been advised to include `tax_area_id` in customer payloads. This should prevent a "double hop" scenario since we will not need to geocode addresses to resolve the id at the time of request.

In order to get the tax area ids, we will add a new endpoint and allow client applications to geocode addresses ahead of time, such as when payments are initially collected.