### PR TITLE
✌️  Add Response::LineItemProduct

### DIFF
--- a/lib/vertex_client.rb
+++ b/lib/vertex_client.rb
@@ -35,6 +35,7 @@ module VertexClient
     autoload :DistributeTax,        'vertex_client/responses/distribute_tax'
     autoload :Invoice,              'vertex_client/responses/invoice'
     autoload :LineItem,             'vertex_client/responses/line_item'
+    autoload :LineItemProduct,      'vertex_client/responses/line_item_product'
     autoload :Quotation,            'vertex_client/responses/quotation'
     autoload :QuotationFallback,    'vertex_client/responses/quotation_fallback'
     autoload :TaxArea,              'vertex_client/responses/tax_area'

--- a/lib/vertex_client/responses/line_item.rb
+++ b/lib/vertex_client/responses/line_item.rb
@@ -5,7 +5,7 @@ module VertexClient
       attr_reader :total_tax, :product, :quantity, :price
 
       def initialize(params={})
-        @product        = params[:product]
+        @product        = LineItemProduct.new(params[:product])
         @quantity       = params[:quantity] ? params[:quantity].to_i : 0
         @price          = BigDecimal.new(params[:price] || 0)
         @total_tax      = BigDecimal.new(params[:total_tax] || 0)

--- a/lib/vertex_client/responses/line_item_product.rb
+++ b/lib/vertex_client/responses/line_item_product.rb
@@ -1,0 +1,17 @@
+module VertexClient
+  module Response
+    class LineItemProduct
+
+      attr_reader :product_code, :product_class
+
+      def initialize(params)
+        if params.is_a?(Hash)
+          @product_code   = params[:content!]
+          @product_class  = params[:@productClass]
+        else
+          @product_code   = params
+        end
+      end
+    end
+  end
+end

--- a/lib/vertex_client/responses/quotation.rb
+++ b/lib/vertex_client/responses/quotation.rb
@@ -17,7 +17,7 @@ module VertexClient
       def line_items
         @line_items ||= @body[:line_item].flatten.map do |line_item|
           LineItem.new(
-            product:        product_for_line_item(line_item),
+            product:        line_item[:product],
             quantity:       line_item[:quantity],
             price:          line_item[:extended_price],
             total_tax:      tax_for_line_item(line_item)
@@ -29,10 +29,6 @@ module VertexClient
 
       def tax_for_line_item(line_item)
         line_item[:total_tax]
-      end
-
-      def product_for_line_item(line_item)
-        line_item[:product]
       end
     end
   end

--- a/lib/vertex_client/responses/quotation_fallback.rb
+++ b/lib/vertex_client/responses/quotation_fallback.rb
@@ -33,10 +33,6 @@ module VertexClient
         state = line_item[:customer][:destination][:main_division]
         tax_amount(price, state)
       end
-
-      def product_for_line_item(line_item)
-        line_item[:product][:content!]
-      end
     end
   end
 end

--- a/test/responses/invoice_test.rb
+++ b/test/responses/invoice_test.rb
@@ -33,7 +33,7 @@ describe VertexClient::Response::Invoice do
   describe 'line_items' do
     it 'is a collection of Response::LineItem' do
       assert_equal 1,       response.line_items.size
-      assert_equal '4600',  response.line_items.first.product
+      assert_equal '4600',  response.line_items.first.product.product_code
       assert_equal 1,       response.line_items.first.quantity
       assert_equal 100.0,   response.line_items.first.price.to_f
     end

--- a/test/responses/line_item_product_test.rb
+++ b/test/responses/line_item_product_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+describe VertexClient::Response::LineItemProduct do
+  let(:product_attributes) do
+    {
+      :'content!'     =>  '4600',
+      :@productClass  =>  '1234'
+    }
+  end
+
+  it 'initializes from the a product hash' do
+    product = VertexClient::Response::LineItemProduct.new(product_attributes)
+    assert_equal '4600', product.product_code
+    assert_equal '1234', product.product_class
+  end
+
+  it 'initializes with a string, too' do
+    product = VertexClient::Response::LineItemProduct.new('4601')
+    assert_equal '4601', product.product_code
+  end
+end

--- a/test/responses/line_item_test.rb
+++ b/test/responses/line_item_test.rb
@@ -12,8 +12,8 @@ describe VertexClient::Response::LineItem do
 
   it 'initializes from the response hash' do
     item = VertexClient::Response::LineItem.new(response_line_item)
+    assert_kind_of VertexClient::Response::LineItemProduct, item.product
     assert_equal response_line_item[:total_tax].to_d, item.total_tax
-    assert_equal response_line_item[:product],        item.product
     assert_equal response_line_item[:quantity].to_f,  item.quantity
     assert_equal response_line_item[:price].to_d,     item.price
   end

--- a/test/responses/quotation_fallback_test.rb
+++ b/test/responses/quotation_fallback_test.rb
@@ -34,10 +34,11 @@ describe VertexClient::Response::QuotationFallback do
 
   describe 'line_items' do
     it 'is a collection of Response::LineItem' do
-      assert_equal 2,       response.line_items.size
-      assert_equal '4600',  response.line_items.first.product
-      assert_equal 7,       response.line_items.first.quantity
-      assert_equal 35.5,    response.line_items.first.price.to_f
+      assert_equal 2,          response.line_items.size
+      assert_equal '4600',     response.line_items.first.product.product_code
+      assert_equal '53103000', response.line_items.first.product.product_class
+      assert_equal 7,          response.line_items.first.quantity
+      assert_equal 35.5,       response.line_items.first.price.to_f
     end
   end
 end

--- a/test/responses/quotation_test.rb
+++ b/test/responses/quotation_test.rb
@@ -28,12 +28,13 @@ describe VertexClient::Response::Quotation do
     assert_equal 106.0, response.total.to_f
     assert_equal 100.0, response.subtotal.to_f
     assert_kind_of VertexClient::Response::LineItem, response.line_items.first
+    assert_kind_of VertexClient::Response::LineItemProduct, response.line_items.first.product
   end
 
   describe 'line_items' do
     it 'is a collection of Response::LineItem' do
       assert_equal 1,       response.line_items.size
-      assert_equal '4600',  response.line_items.first.product
+      assert_equal '4600',  response.line_items.first.product.product_code
       assert_equal 1,       response.line_items.first.quantity
       assert_equal 100.0,   response.line_items.first.price.to_f
       assert_equal 6.0,     response.line_items.first.total_tax.to_f


### PR DESCRIPTION
This gives us a consistent way to handle inconsitent responses from savon for product data.