### PR TITLE
✌️ Add Response::LineItemProduct

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -3,6 +3,8 @@
 require "bundler/setup"
 require "dotenv/load"
 require "vertex_client"
+require 'byebug'
+require 'awesome_print'
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/lib/generators/install/templates/initializer.rb.erb
+++ b/lib/generators/install/templates/initializer.rb.erb
@@ -1,5 +1,5 @@
 # Uncomment the next line if you want to use circuitbox with VertexClient.
-# require "circuitbox"
+# require 'circuitbox'
 VertexClient.configure do |config|
   config.trusted_id = ENV.fetch('VERTEX_TRUSTED_ID')
   config.soap_api = ENV.fetch('VERTEX_SOAP_API')

--- a/lib/vertex_client.rb
+++ b/lib/vertex_client.rb
@@ -35,6 +35,7 @@ module VertexClient
     autoload :DistributeTax,        'vertex_client/responses/distribute_tax'
     autoload :Invoice,              'vertex_client/responses/invoice'
     autoload :LineItem,             'vertex_client/responses/line_item'
+    autoload :LineItemProduct,      'vertex_client/responses/line_item_product'
     autoload :Quotation,            'vertex_client/responses/quotation'
     autoload :QuotationFallback,    'vertex_client/responses/quotation_fallback'
     autoload :TaxArea,              'vertex_client/responses/tax_area'

--- a/lib/vertex_client/connection.rb
+++ b/lib/vertex_client/connection.rb
@@ -1,7 +1,7 @@
 module VertexClient
   class Connection
 
-    VERTEX_NAMESPACE = "urn:vertexinc:o-series:tps:7:0".freeze
+    VERTEX_NAMESPACE = 'urn:vertexinc:o-series:tps:7:0'.freeze
     ERROR_MESSAGE = 'The Vertex API returned an error or is unavailable'.freeze
 
     def initialize(endpoint)

--- a/lib/vertex_client/responses/line_item.rb
+++ b/lib/vertex_client/responses/line_item.rb
@@ -5,7 +5,7 @@ module VertexClient
       attr_reader :total_tax, :product, :quantity, :price
 
       def initialize(params={})
-        @product        = LineItemProduct.new(params[:product])
+        @product        = LineItemProduct.new(params[:product] || {})
         @quantity       = params[:quantity] ? params[:quantity].to_i : 0
         @price          = BigDecimal.new(params[:price] || 0)
         @total_tax      = BigDecimal.new(params[:total_tax] || 0)

--- a/lib/vertex_client/responses/line_item.rb
+++ b/lib/vertex_client/responses/line_item.rb
@@ -5,7 +5,7 @@ module VertexClient
       attr_reader :total_tax, :product, :quantity, :price
 
       def initialize(params={})
-        @product        = params[:product]
+        @product        = LineItemProduct.new(params[:product])
         @quantity       = params[:quantity] ? params[:quantity].to_i : 0
         @price          = BigDecimal.new(params[:price] || 0)
         @total_tax      = BigDecimal.new(params[:total_tax] || 0)

--- a/lib/vertex_client/responses/line_item_product.rb
+++ b/lib/vertex_client/responses/line_item_product.rb
@@ -5,10 +5,12 @@ module VertexClient
       attr_reader :product_code, :product_class
 
       def initialize(params)
-        if params.is_a?(Hash)
-          @product_code   = params[:content!]
-        else
+        if params.is_a?(Nori::StringWithAttributes)
           @product_code   = params
+          @product_class  = params.attributes['productClass']
+        else
+          @product_code   = params[:content!]
+          @product_class  = params[:@productClass]
         end
       end
     end

--- a/lib/vertex_client/responses/line_item_product.rb
+++ b/lib/vertex_client/responses/line_item_product.rb
@@ -1,0 +1,16 @@
+module VertexClient
+  module Response
+    class LineItemProduct
+
+      attr_reader :product_code, :product_class
+
+      def initialize(params)
+        if params.is_a?(Hash)
+          @product_code   = params[:content!]
+        else
+          @product_code   = params
+        end
+      end
+    end
+  end
+end

--- a/lib/vertex_client/responses/quotation.rb
+++ b/lib/vertex_client/responses/quotation.rb
@@ -17,7 +17,7 @@ module VertexClient
       def line_items
         @line_items ||= @body[:line_item].flatten.map do |line_item|
           LineItem.new(
-            product:        product_for_line_item(line_item),
+            product:        line_item[:product],
             quantity:       line_item[:quantity],
             price:          line_item[:extended_price],
             total_tax:      tax_for_line_item(line_item)
@@ -29,10 +29,6 @@ module VertexClient
 
       def tax_for_line_item(line_item)
         line_item[:total_tax]
-      end
-
-      def product_for_line_item(line_item)
-        line_item[:product]
       end
     end
   end

--- a/lib/vertex_client/responses/quotation_fallback.rb
+++ b/lib/vertex_client/responses/quotation_fallback.rb
@@ -24,7 +24,7 @@ module VertexClient
         if RATES.has_key?(state)
           price * BigDecimal.new(RATES[state])
         else
-          BigDecimal.new("0.0")
+          BigDecimal.new('0.0')
         end
       end
 

--- a/lib/vertex_client/responses/quotation_fallback.rb
+++ b/lib/vertex_client/responses/quotation_fallback.rb
@@ -33,10 +33,6 @@ module VertexClient
         state = line_item[:customer][:destination][:main_division]
         tax_amount(price, state)
       end
-
-      def product_for_line_item(line_item)
-        line_item[:product][:content!]
-      end
     end
   end
 end

--- a/lib/vertex_client/version.rb
+++ b/lib/vertex_client/version.rb
@@ -1,3 +1,3 @@
 module VertexClient
-  VERSION = "0.6.2"
+  VERSION = '0.6.3'
 end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 describe 'Integration' do
   include TestInput
@@ -12,7 +12,7 @@ describe 'Integration' do
   end
 
   it 'does a quotation' do
-    VCR.use_cassette("quotation", :match_requests_on => []) do
+    VCR.use_cassette('quotation', :match_requests_on => []) do
       response = VertexClient.quotation(working_quote_params)
       assert_equal 1.52, response.total_tax
       assert_equal '4600', response.line_items.first.product.product_code
@@ -21,27 +21,27 @@ describe 'Integration' do
   end
 
   it 'does an invoice' do
-    VCR.use_cassette("invoice", :match_requests_on => []) do
+    VCR.use_cassette('invoice', :match_requests_on => []) do
       response = VertexClient.invoice(working_quote_params)
       assert_equal 1.52, response.total_tax
     end
   end
 
   it 'does distribute_tax' do
-    VCR.use_cassette("distribute_tax", :match_requests_on => []) do
+    VCR.use_cassette('distribute_tax', :match_requests_on => []) do
       VertexClient.distribute_tax(distribute_tax_params)
     end
   end
 
   it 'does tax_area' do
-    VCR.use_cassette("tax_area", :match_requests_on => []) do
-      assert_equal "470590000", VertexClient.tax_area(tax_area_params).tax_area_id
+    VCR.use_cassette('tax_area', :match_requests_on => []) do
+      assert_equal '470590000', VertexClient.tax_area(tax_area_params).tax_area_id
     end
   end
 
   it 'does tax_area for results with multiple responses' do
-    VCR.use_cassette("tax_area_multiple", :match_requests_on => []) do
-      assert_equal "420130010", VertexClient.tax_area({
+    VCR.use_cassette('tax_area_multiple', :match_requests_on => []) do
+      assert_equal '420130010', VertexClient.tax_area({
         address_1: '126487 N Bridge Rd',
         city: 'Aberdeen',
         state: 'SD',
@@ -52,7 +52,7 @@ describe 'Integration' do
 
   it 'uses circuit if it is available' do
     VertexClient.configuration.circuit_config = {}
-    VCR.use_cassette("quotation", :match_requests_on => []) do
+    VCR.use_cassette('quotation', :match_requests_on => []) do
       VertexClient.quotation(working_quote_params)
     end
   end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -15,6 +15,8 @@ describe 'Integration' do
     VCR.use_cassette("quotation", :match_requests_on => []) do
       response = VertexClient.quotation(working_quote_params)
       assert_equal 1.52, response.total_tax
+      assert_equal '4600', response.line_items.first.product.product_code
+      assert_equal '53103000', response.line_items.first.product.product_class
     end
   end
 

--- a/test/payload_validator_test.rb
+++ b/test/payload_validator_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 describe 'payload validation' do
   include TestInput

--- a/test/payloads/base_test.rb
+++ b/test/payloads/base_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 describe VertexClient::Payload::Base do
   class VertexClient::Payload::Dummy < VertexClient::Payload::Base

--- a/test/payloads/distribute_tax_test.rb
+++ b/test/payloads/distribute_tax_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 describe VertexClient::Payload::DistributeTax do
   include TestInput

--- a/test/payloads/invoice_test.rb
+++ b/test/payloads/invoice_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 describe VertexClient::Payload::Invoice do
   include TestInput

--- a/test/payloads/quotation_fallback_test.rb
+++ b/test/payloads/quotation_fallback_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 describe VertexClient::Payload::QuotationFallback do
   include TestInput
@@ -9,11 +9,11 @@ describe VertexClient::Payload::QuotationFallback do
 
   it 'does not include tax_area_id in the body' do
     expected_destination = {
-      street_address_1: "11 Wall Street",
-      city: "New York",
-      main_division: "NY",
-      postal_code: "10005",
-      country: "US"
+      street_address_1: '11 Wall Street',
+      city: 'New York',
+      main_division: 'NY',
+      postal_code: '10005',
+      country: 'US'
     }
     assert_equal expected_destination, payload.body[:line_item][0][:customer][:destination]
   end

--- a/test/payloads/quotation_test.rb
+++ b/test/payloads/quotation_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 describe VertexClient::Payload::Quotation do
   include TestInput

--- a/test/resources/base_test.rb
+++ b/test/resources/base_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 describe VertexClient::Resource::Base do
   class VertexClient::Resource::MyTest  < VertexClient::Resource::Base

--- a/test/resources/distribute_tax_test.rb
+++ b/test/resources/distribute_tax_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 describe VertexClient::Resource::DistributeTax do
   include TestInput

--- a/test/resources/invoice_test.rb
+++ b/test/resources/invoice_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 describe VertexClient::Resource::Invoice do
   include TestInput

--- a/test/resources/quotation_test.rb
+++ b/test/resources/quotation_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 describe VertexClient::Resource::Quotation do
   include TestInput

--- a/test/resources/tax_area_test.rb
+++ b/test/resources/tax_area_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 describe VertexClient::Resource::TaxArea do
   include TestInput

--- a/test/responses/base_test.rb
+++ b/test/responses/base_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 describe VertexClient::Response::Base do
   class VertexClient::Response::MyClass < VertexClient::Response::Base; end

--- a/test/responses/distribute_tax_test.rb
+++ b/test/responses/distribute_tax_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 describe VertexClient::Response::DistributeTax do
   let(:vertex_quotation_response) do

--- a/test/responses/invoice_test.rb
+++ b/test/responses/invoice_test.rb
@@ -33,7 +33,7 @@ describe VertexClient::Response::Invoice do
   describe 'line_items' do
     it 'is a collection of Response::LineItem' do
       assert_equal 1,       response.line_items.size
-      assert_equal '4600',  response.line_items.first.product
+      assert_equal '4600',  response.line_items.first.product.product_code
       assert_equal 1,       response.line_items.first.quantity
       assert_equal 100.0,   response.line_items.first.price.to_f
     end

--- a/test/responses/invoice_test.rb
+++ b/test/responses/invoice_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 describe VertexClient::Response::Invoice do
+  include TestInput
+
   let(:vertex_quotation_response) do
     OpenStruct.new(body: {
       vertex_envelope: {
@@ -13,7 +15,7 @@ describe VertexClient::Response::Invoice do
               quantity: '1',
               extended_price: '100',
               total_tax: '6.0',
-              product: '4600'
+              product: fake_product_response
             }
           ]
         }
@@ -34,6 +36,7 @@ describe VertexClient::Response::Invoice do
     it 'is a collection of Response::LineItem' do
       assert_equal 1,       response.line_items.size
       assert_equal '4600',  response.line_items.first.product.product_code
+      assert_equal '1337',  response.line_items.first.product.product_class
       assert_equal 1,       response.line_items.first.quantity
       assert_equal 100.0,   response.line_items.first.price.to_f
     end

--- a/test/responses/invoice_test.rb
+++ b/test/responses/invoice_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 describe VertexClient::Response::Invoice do
   include TestInput

--- a/test/responses/line_item_product_test.rb
+++ b/test/responses/line_item_product_test.rb
@@ -1,19 +1,23 @@
 require 'test_helper'
 
 describe VertexClient::Response::LineItemProduct do
-  let(:product_attributes) do
+
+  include TestInput
+
+  let(:product_input_hash) do
     {
       :'content!'     =>  '4600',
     }
   end
 
-  it 'initializes from the a product hash' do
-    product = VertexClient::Response::LineItemProduct.new(product_attributes)
+  it 'initialized from an input hash' do
+    product = VertexClient::Response::LineItemProduct.new(product_input_hash)
     assert_equal '4600', product.product_code
   end
 
-  it 'initializes with a string, too' do
-    product = VertexClient::Response::LineItemProduct.new('4601')
-    assert_equal '4601', product.product_code
+  it 'initializes with a Nori::StringWithAttributes when we are looking at a response' do
+    product = VertexClient::Response::LineItemProduct.new(fake_product_response)
+    assert_equal '4600',    product.product_code
+    assert_equal '1337',    product.product_class
   end
 end

--- a/test/responses/line_item_product_test.rb
+++ b/test/responses/line_item_product_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+describe VertexClient::Response::LineItemProduct do
+  let(:product_attributes) do
+    {
+      :'content!'     =>  '4600',
+    }
+  end
+
+  it 'initializes from the a product hash' do
+    product = VertexClient::Response::LineItemProduct.new(product_attributes)
+    assert_equal '4600', product.product_code
+  end
+
+  it 'initializes with a string, too' do
+    product = VertexClient::Response::LineItemProduct.new('4601')
+    assert_equal '4601', product.product_code
+  end
+end

--- a/test/responses/line_item_test.rb
+++ b/test/responses/line_item_test.rb
@@ -12,8 +12,8 @@ describe VertexClient::Response::LineItem do
 
   it 'initializes from the response hash' do
     item = VertexClient::Response::LineItem.new(response_line_item)
+    assert_kind_of VertexClient::Response::LineItemProduct, item.product
     assert_equal response_line_item[:total_tax].to_d, item.total_tax
-    assert_equal response_line_item[:product],        item.product
     assert_equal response_line_item[:quantity].to_f,  item.quantity
     assert_equal response_line_item[:price].to_d,     item.price
   end

--- a/test/responses/line_item_test.rb
+++ b/test/responses/line_item_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 describe VertexClient::Response::LineItem do
   include TestInput

--- a/test/responses/line_item_test.rb
+++ b/test/responses/line_item_test.rb
@@ -1,10 +1,12 @@
 require "test_helper"
 
 describe VertexClient::Response::LineItem do
+  include TestInput
+
   let(:response_line_item) do
     {
       total_tax:  '6.0',
-      product:    '4600',
+      product:    fake_product_response,
       quantity:   '1',
       price:      '100'
     }

--- a/test/responses/quotation_fallback_test.rb
+++ b/test/responses/quotation_fallback_test.rb
@@ -34,10 +34,10 @@ describe VertexClient::Response::QuotationFallback do
 
   describe 'line_items' do
     it 'is a collection of Response::LineItem' do
-      assert_equal 2,       response.line_items.size
-      assert_equal '4600',  response.line_items.first.product
-      assert_equal 7,       response.line_items.first.quantity
-      assert_equal 35.5,    response.line_items.first.price.to_f
+      assert_equal 2,          response.line_items.size
+      assert_equal '4600',     response.line_items.first.product.product_code
+      assert_equal 7,          response.line_items.first.quantity
+      assert_equal 35.5,       response.line_items.first.price.to_f
     end
   end
 end

--- a/test/responses/quotation_fallback_test.rb
+++ b/test/responses/quotation_fallback_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 describe VertexClient::Response::QuotationFallback do
   include TestInput

--- a/test/responses/quotation_test.rb
+++ b/test/responses/quotation_test.rb
@@ -28,12 +28,13 @@ describe VertexClient::Response::Quotation do
     assert_equal 106.0, response.total.to_f
     assert_equal 100.0, response.subtotal.to_f
     assert_kind_of VertexClient::Response::LineItem, response.line_items.first
+    assert_kind_of VertexClient::Response::LineItemProduct, response.line_items.first.product
   end
 
   describe 'line_items' do
     it 'is a collection of Response::LineItem' do
       assert_equal 1,       response.line_items.size
-      assert_equal '4600',  response.line_items.first.product
+      assert_equal '4600',  response.line_items.first.product.product_code
       assert_equal 1,       response.line_items.first.quantity
       assert_equal 100.0,   response.line_items.first.price.to_f
       assert_equal 6.0,     response.line_items.first.total_tax.to_f

--- a/test/responses/quotation_test.rb
+++ b/test/responses/quotation_test.rb
@@ -1,6 +1,9 @@
 require "test_helper"
 
 describe VertexClient::Response::Quotation do
+
+ include TestInput
+
   let(:vertex_quotation_response) do
     OpenStruct.new(body: {
       vertex_envelope: {
@@ -13,7 +16,7 @@ describe VertexClient::Response::Quotation do
               quantity: '1',
               extended_price: '100',
               total_tax: '6.0',
-              product: '4600'
+              product: fake_product_response('4600', '1234')
             }
           ]
         }

--- a/test/responses/quotation_test.rb
+++ b/test/responses/quotation_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 describe VertexClient::Response::Quotation do
 

--- a/test/responses/tax_area_fallback_test.rb
+++ b/test/responses/tax_area_fallback_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 describe VertexClient::Response::TaxAreaFallback do
   it 'has a nil tax_area_id' do

--- a/test/responses/tax_area_test.rb
+++ b/test/responses/tax_area_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 describe VertexClient::Response::TaxArea do
   let(:vertex_tax_area_response) do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -204,6 +204,13 @@ module TestInput
           ]
         }
       end
+
+      def fake_product_response(product_code='4600', product_class='1337')
+        product = Nori::StringWithAttributes.new(product_code)
+        product.attributes = { 'productClass' => product_class }
+        product
+      end
+
     end
   end
 end

--- a/test/utils/adjustment_allocator_test.rb
+++ b/test/utils/adjustment_allocator_test.rb
@@ -57,32 +57,32 @@ describe VertexClient::Utils::AdjustmentAllocator do
       assert_equal price_allocation, ratio_allocation
     end
 
-    it "handles an empty array of weights if the adjustment amount is 0" do
+    it 'handles an empty array of weights if the adjustment amount is 0' do
       assert_equal [], VertexClient::Utils::AdjustmentAllocator.new(0, []).allocate
     end
 
-    describe "allocating remainder pennies perfectly" do
+    describe 'allocating remainder pennies perfectly' do
       let(:one_penny)           { '0.01'.to_d }
       let(:two_pennies)         { '0.02'.to_d }
       let(:three_pennies)       { '0.03'.to_d }
 
       # on first pass, each one gets 0 pennies and has a remainder of $0.006.
       # 5-way tie on the remainder, so the last three will each get one
-      it "assigns remainder pennies, breaking ties by going with the last" do
+      it 'assigns remainder pennies, breaking ties by going with the last' do
         expected = [0, 0, one_penny, one_penny, one_penny]
         assert_equal expected, VertexClient::Utils::AdjustmentAllocator.new(three_pennies, [1.0, 1.0, 1.0, 1.0, 1.0]).allocate
       end
 
       # 2.0 weight wins for the first remainder penny.
       # Then, after 3-way second place tie for $0.004, the last one gets the penny
-      it "assigns remainder pennies, breaking second place ties" do
+      it 'assigns remainder pennies, breaking second place ties' do
        expected = [0, 0, one_penny, one_penny]
        assert_equal expected, VertexClient::Utils::AdjustmentAllocator.new(two_pennies, [1.0, 1.0, 2.0, 1.0]).allocate
       end
 
       # 6.0 gets a penny outright. Then all have remainder of $0.002
       # To break tie, we give the extra penny to the last.
-      it "assigns remainder pennies, regardless of pennies already assigned" do
+      it 'assigns remainder pennies, regardless of pennies already assigned' do
         expected = [0, 0, 0, 0, two_pennies]
         assert_equal expected, VertexClient::Utils::AdjustmentAllocator.new(two_pennies, [1.0, 1.0, 1.0, 1.0, 6.0]).allocate
       end

--- a/test/vertex_client_test.rb
+++ b/test/vertex_client_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 describe VertexClient do
 
@@ -76,12 +76,12 @@ describe VertexClient do
           logger: FakeLogger.new
         }
 
-        # "Not Open" means that we are actively hitting the service.
+        # 'Not Open' means that we are actively hitting the service.
         VertexClient.configuration.trusted_id  = '💩'
         refute VertexClient.circuit.open?
 
         # Exhaust the configured volume threshold to open the circuit.
-        # "Open" means that we aren't going to connect to the service.
+        # 'Open' means that we aren't going to connect to the service.
         threads = []
         (VertexClient::Configuration::CIRCUIT_CONFIG[:volume_threshold] + 1).times do
           threads << Thread.new { VertexClient.quotation(working_quote_params) }

--- a/vertex_client.gemspec
+++ b/vertex_client.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "activesupport"
   spec.add_dependency "savon", ">= 2.11"
+  spec.add_development_dependency "awesome_print"
   spec.add_development_dependency "circuitbox"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "byebug"


### PR DESCRIPTION
This gives us a consistent way to handle inconsitent responses from savon for product data.

Related to:
https://github.com/savonrb/nori/issues/59