### PR TITLE
👄 Simplify Response::LineItemProduct

### DIFF
--- a/lib/vertex_client/responses/line_item.rb
+++ b/lib/vertex_client/responses/line_item.rb
@@ -5,7 +5,7 @@ module VertexClient
       attr_reader :total_tax, :product, :quantity, :price
 
       def initialize(params={})
-        @product        = LineItemProduct.new(params[:product] || {})
+        @product        = params[:product]
         @quantity       = params[:quantity] ? params[:quantity].to_i : 0
         @price          = BigDecimal.new(params[:price] || 0)
         @total_tax      = BigDecimal.new(params[:total_tax] || 0)

--- a/lib/vertex_client/responses/line_item_product.rb
+++ b/lib/vertex_client/responses/line_item_product.rb
@@ -5,13 +5,8 @@ module VertexClient
       attr_reader :product_code, :product_class
 
       def initialize(params)
-        if params.is_a?(Nori::StringWithAttributes)
-          @product_code   = params
-          @product_class  = params.attributes['productClass']
-        else
-          @product_code   = params[:content!]
-          @product_class  = params[:@productClass]
-        end
+        @product_code   = params[:product_code]
+        @product_class  = params[:product_class]
       end
     end
   end

--- a/lib/vertex_client/responses/quotation.rb
+++ b/lib/vertex_client/responses/quotation.rb
@@ -17,7 +17,7 @@ module VertexClient
       def line_items
         @line_items ||= @body[:line_item].flatten.map do |line_item|
           LineItem.new(
-            product:        line_item[:product],
+            product:        product_for_line_item(line_item[:product]),
             quantity:       line_item[:quantity],
             price:          line_item[:extended_price],
             total_tax:      tax_for_line_item(line_item)
@@ -26,6 +26,20 @@ module VertexClient
       end
 
       private
+
+      def product_for_line_item(product)
+        if(product).is_a?(Nori::StringWithAttributes)
+          LineItemProduct.new(
+            product_code:   product.to_s,
+            product_class:  product.attributes['productClass'],
+          )
+        else
+          LineItemProduct.new(
+            product_code:   product['@product_code'],
+            product_class:  product['@product_class'],
+          )
+        end
+      end
 
       def tax_for_line_item(line_item)
         line_item[:total_tax]

--- a/lib/vertex_client/responses/quotation_fallback.rb
+++ b/lib/vertex_client/responses/quotation_fallback.rb
@@ -20,6 +20,13 @@ module VertexClient
 
       private
 
+      def product_for_line_item(product)
+        LineItemProduct.new(
+          product_code:   product[:content!],
+          product_class:  product[:@productClass],
+        )
+      end
+
       def tax_amount(price, state)
         if RATES.has_key?(state)
           price * BigDecimal.new(RATES[state])

--- a/lib/vertex_client/version.rb
+++ b/lib/vertex_client/version.rb
@@ -1,3 +1,3 @@
 module VertexClient
-  VERSION = '0.6.3'
+  VERSION = '0.6.4'
 end

--- a/test/responses/line_item_product_test.rb
+++ b/test/responses/line_item_product_test.rb
@@ -4,19 +4,11 @@ describe VertexClient::Response::LineItemProduct do
 
   include TestInput
 
-  let(:product_input_hash) do
-    {
-      :'content!'     =>  '4600',
-    }
-  end
-
-  it 'initialized from an input hash' do
-    product = VertexClient::Response::LineItemProduct.new(product_input_hash)
-    assert_equal '4600', product.product_code
-  end
-
-  it 'initializes with a Nori::StringWithAttributes when we are looking at a response' do
-    product = VertexClient::Response::LineItemProduct.new(fake_product_response)
+  it 'initializes' do
+    product = VertexClient::Response::LineItemProduct.new(
+      product_class:  fake_product_response.attributes['productClass'],
+      product_code:   fake_product_response.to_s
+    )
     assert_equal '4600',    product.product_code
     assert_equal '1337',    product.product_class
   end

--- a/test/responses/line_item_test.rb
+++ b/test/responses/line_item_test.rb
@@ -6,18 +6,18 @@ describe VertexClient::Response::LineItem do
   let(:response_line_item) do
     {
       total_tax:  '6.0',
-      product:    fake_product_response,
       quantity:   '1',
-      price:      '100'
+      price:      '100',
+      product:    'test'
     }
   end
 
-  it 'initializes from the response hash' do
+  it 'initializes from a hash' do
     item = VertexClient::Response::LineItem.new(response_line_item)
-    assert_kind_of VertexClient::Response::LineItemProduct, item.product
     assert_equal response_line_item[:total_tax].to_d, item.total_tax
     assert_equal response_line_item[:quantity].to_f,  item.quantity
     assert_equal response_line_item[:price].to_d,     item.price
+    assert_equal response_line_item[:product],        item.product
   end
 
   it 'is safe about assignment and casting of nil params' do

--- a/test/responses/quotation_fallback_test.rb
+++ b/test/responses/quotation_fallback_test.rb
@@ -36,6 +36,7 @@ describe VertexClient::Response::QuotationFallback do
     it 'is a collection of Response::LineItem' do
       assert_equal 2,          response.line_items.size
       assert_equal '4600',     response.line_items.first.product.product_code
+      assert_equal '53103000', response.line_items.first.product.product_class
       assert_equal 7,          response.line_items.first.quantity
       assert_equal 35.5,       response.line_items.first.price.to_f
     end

--- a/test/responses/quotation_test.rb
+++ b/test/responses/quotation_test.rb
@@ -24,6 +24,14 @@ describe VertexClient::Response::Quotation do
     })
   end
 
+  let(:empty_product_response) do
+    parser = Nori.new(:convert_tags_to => lambda { |tag| tag.snakecase.to_sym })
+    lip = parser.parse('<product productClass="my_awesome_class" />')
+    resp = vertex_quotation_response.dup
+    resp.body[:vertex_envelope][:quotation_response][:line_item] = [lip]
+    resp
+  end
+
   let(:response) { VertexClient::Response::Quotation.new(vertex_quotation_response) }
 
   it 'has attributes' do
@@ -38,9 +46,16 @@ describe VertexClient::Response::Quotation do
     it 'is a collection of Response::LineItem' do
       assert_equal 1,       response.line_items.size
       assert_equal '4600',  response.line_items.first.product.product_code
+      assert_equal '1234',  response.line_items.first.product.product_class
       assert_equal 1,       response.line_items.first.quantity
       assert_equal 100.0,   response.line_items.first.price.to_f
       assert_equal 6.0,     response.line_items.first.total_tax.to_f
+    end
+
+    it 'parses products that do not have text values/product_codes' do
+      alt_response = VertexClient::Response::Quotation.new(empty_product_response)
+      assert_nil alt_response.line_items.first.product.product_code
+      assert_equal 'my_awesome_class', alt_response.line_items.first.product.product_class
     end
   end
 end


### PR DESCRIPTION
## Why
When parsing returned `LineItemProduct` values from Quotation/Invoice/DistributeTax, we get one of 2 types of objects back from `Savon`:
* Typically: a `Nori::StringWithAttributes`, when a product **has** a `product code` specified.
* Less common: a `Hash`, when a product **does not have** a  `product code` specified.

Also, when we are in the fallback scenario, we are dealing with a varied input format based on our `Payload` rather than the `Savon` response.

Because the construction of these `LineItemProduct` objects is so varied, we move the responsibility for creating them properly into the objects generating the `Response`, and turn `LineItemProduct` into a simple value store.