### PR TITLE
Adds open and read timeouts to client

### DIFF
--- a/lib/vertex_client/configuration.rb
+++ b/lib/vertex_client/configuration.rb
@@ -13,7 +13,8 @@ module VertexClient
       ]
     }.freeze
 
-    attr_accessor :trusted_id, :soap_api, :circuit_config
+    attr_accessor :trusted_id, :soap_api, :circuit_config, :open_timeout,
+      :read_timeout
 
     def initialize
       @trusted_id = ENV['VERTEX_TRUSTED_ID']

--- a/lib/vertex_client/connection.rb
+++ b/lib/vertex_client/connection.rb
@@ -24,6 +24,8 @@ module VertexClient
         globals.convert_request_keys_to :camelcase
         globals.env_namespace :soapenv
         globals.namespace_identifier :urn
+        globals.read_timeout open_timeout if open_timeout
+        globals.read_timeout read_timeout if read_timeout
       end
     end
 
@@ -53,6 +55,14 @@ module VertexClient
 
     def clean_endpoint
       URI.join(config.soap_api, @endpoint).to_s
+    end
+
+    def read_timeout
+      config.read_timeout
+    end
+
+    def open_timeout
+      config.open_timeout
     end
   end
 end

--- a/lib/vertex_client/version.rb
+++ b/lib/vertex_client/version.rb
@@ -1,3 +1,3 @@
 module VertexClient
-  VERSION = '0.6.5'
+  VERSION = '0.6.6'
 end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -17,6 +17,16 @@ describe VertexClient::Configuration do
     VertexClient.reconfigure!
   end
 
+  it 'has a read_timeout options' do
+    VertexClient.configuration.read_timeout = 5
+    assert_equal 5, VertexClient.configuration.read_timeout
+  end
+
+  it 'has an open_timeout options' do
+    VertexClient.configuration.open_timeout = 5
+    assert_equal 5, VertexClient.configuration.open_timeout
+  end
+
   describe 'circuit_config' do
     before do
       VertexClient.reconfigure!


### PR DESCRIPTION
Setting this configuration will set the read or open timeout globally. One improvement to this may be to enable configuration of timeouts on a resource level (quotation, invoice, etc).