### PR TITLE
Update BigDecimal initialisation syntax

### DIFF
--- a/lib/vertex_client/responses/distribute_tax.rb
+++ b/lib/vertex_client/responses/distribute_tax.rb
@@ -2,15 +2,15 @@ module VertexClient
   module Response
     class DistributeTax < Base
       def subtotal
-        @subtotal ||= BigDecimal.new(@body[:sub_total])
+        @subtotal ||= BigDecimal(@body[:sub_total])
       end
 
       def total_tax
-        @total_tax ||= BigDecimal.new(@body[:total_tax])
+        @total_tax ||= BigDecimal(@body[:total_tax])
       end
 
       def total
-        @total ||= BigDecimal.new(@body[:total])
+        @total ||= BigDecimal(@body[:total])
       end
     end
   end

--- a/lib/vertex_client/responses/line_item.rb
+++ b/lib/vertex_client/responses/line_item.rb
@@ -7,8 +7,8 @@ module VertexClient
       def initialize(params={})
         @product        = params[:product]
         @quantity       = params[:quantity] ? params[:quantity].to_i : 0
-        @price          = BigDecimal.new(params[:price] || 0)
-        @total_tax      = BigDecimal.new(params[:total_tax] || 0)
+        @price          = BigDecimal(params[:price] || 0)
+        @total_tax      = BigDecimal(params[:total_tax] || 0)
       end
     end
   end

--- a/lib/vertex_client/responses/quotation.rb
+++ b/lib/vertex_client/responses/quotation.rb
@@ -3,15 +3,15 @@ module VertexClient
     class Quotation < Base
 
       def subtotal
-        @subtotal ||= BigDecimal.new(@body[:sub_total])
+        @subtotal ||= BigDecimal(@body[:sub_total])
       end
 
       def total_tax
-        @total_tax ||= BigDecimal.new(@body[:total_tax])
+        @total_tax ||= BigDecimal(@body[:total_tax])
       end
 
       def total
-        @total ||= BigDecimal.new(@body[:total])
+        @total ||= BigDecimal(@body[:total])
       end
 
       def line_items

--- a/lib/vertex_client/responses/quotation_fallback.rb
+++ b/lib/vertex_client/responses/quotation_fallback.rb
@@ -29,14 +29,14 @@ module VertexClient
 
       def tax_amount(price, state)
         if RATES.has_key?(state)
-          price * BigDecimal.new(RATES[state])
+          price * BigDecimal(RATES[state])
         else
-          BigDecimal.new('0.0')
+          BigDecimal('0.0')
         end
       end
 
       def tax_for_line_item(line_item)
-        price = BigDecimal.new(line_item[:extended_price].to_s)
+        price = BigDecimal(line_item[:extended_price].to_s)
         state = line_item[:customer][:destination][:main_division]
         tax_amount(price, state)
       end


### PR DESCRIPTION
### Description

`BigDecimal.new()` was [deprecated in Ruby v2.6.0 ](https://github.com/ruby/ruby/blob/v2_6_0/NEWS#stdlib-updates-outstanding-ones-only) and results in deprecation warning. 

### Changes

I've updated `BigDecimal` initialisation syntax from the deprecated `BigDecimal.new()` to `BigDecimal()`. 

### Notes

These changes are only relevant for developers using Ruby v2.6.0+ and don't affect developers using previous versions of Ruby. 