### PR TITLE
Support Savon's HTTPI adapter config.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 This file tracks all the changes made to the client.
 This allows parsers such as Dependabot to provide a clean overview in pull requests.
 
+## v0.8.0
+
+- Added: New HTTP adapter config.
+
+
 ## v0.7.0
 
 - Introduced CHANGELOG.md

--- a/lib/vertex_client/configuration.rb
+++ b/lib/vertex_client/configuration.rb
@@ -14,7 +14,7 @@ module VertexClient
     }.freeze
 
     attr_accessor :trusted_id, :soap_api, :circuit_config, :open_timeout,
-      :read_timeout, :resource_config
+      :read_timeout, :resource_config, :adapter
 
     def initialize
       @trusted_id = ENV['VERTEX_TRUSTED_ID']

--- a/lib/vertex_client/connection.rb
+++ b/lib/vertex_client/connection.rb
@@ -19,7 +19,7 @@ module VertexClient
     end
 
     def client
-      @client ||= Savon.client do |globals|
+      @client ||= Savon.client(adapter: adapter) do |globals|
         globals.endpoint clean_endpoint
         globals.namespace VERTEX_NAMESPACE
         globals.convert_request_keys_to :camelcase
@@ -27,7 +27,6 @@ module VertexClient
         globals.namespace_identifier :urn
         globals.open_timeout open_timeout if open_timeout.present?
         globals.read_timeout read_timeout if read_timeout.present?
-        globals.adapter = adapter if adapter
       end
     end
 

--- a/lib/vertex_client/connection.rb
+++ b/lib/vertex_client/connection.rb
@@ -27,6 +27,7 @@ module VertexClient
         globals.namespace_identifier :urn
         globals.open_timeout open_timeout if open_timeout.present?
         globals.read_timeout read_timeout if read_timeout.present?
+        globals.adapter = adapter if adapter
       end
     end
 
@@ -68,6 +69,10 @@ module VertexClient
 
     def open_timeout
       resource_config[:open_timeout] || config.open_timeout
+    end
+
+    def adapter
+      resource_config[:adapter] || config.adapter
     end
   end
 end

--- a/lib/vertex_client/version.rb
+++ b/lib/vertex_client/version.rb
@@ -1,3 +1,3 @@
 module VertexClient
-  VERSION = '0.7.0'
+  VERSION = '0.8.0'
 end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -27,6 +27,11 @@ describe VertexClient::Configuration do
     assert_equal 5, VertexClient.configuration.open_timeout
   end
 
+  it 'has an adapter option' do
+    VertexClient.configuration.adapter = :net_http
+    assert_equal :net_http, VertexClient.configuration.adapter
+  end
+
   describe 'circuit_config' do
     before do
       VertexClient.reconfigure!


### PR DESCRIPTION
We have identified that vertex endpoints are not showing up in both New Relic's external services nor in transaction traces. Likely for the same reason. I have a handful of theories on this and this pull request is to explore one of them. Savon uses it's own HTTPI gem for network connections. That gem has a load order of adapters it would use. See here for those. https://github.com/savonrb/httpi/blob/master/lib/httpi/adapter.rb

For GOF, that would likely land on curb since the gem is available due to MmsClient specs requiring it even this it is not the default. This config would allow us to pass both global and request context adapters using Savon's interface.