### PR TITLE
VertexClient 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 This file tracks all the changes (https://keepachangelog.com/en/1.0.0/) made to the client. This allows parsers such as Dependabot to provide a clean overview in pull requests.
 
+## [v1.0.0] - 2020-03-25
+
+### Changed
+
+- Dropped support for Ruby 2.4 and older, these are end-of-life
+- Set minimum Ruby version to 2.5
+
+### Removed
+
+- `$LOAD_PATH` mingling in the `.gemspec`. Bundler will handle that for us.
+
 ## [v0.9.1] - 2020-03-24
 
 #### Added
@@ -12,7 +23,6 @@ This file tracks all the changes (https://keepachangelog.com/en/1.0.0/) made to 
 #### Changed
 
 - Update quotation validation rules to require either `state` (case of US address) or `country` (other countries)
-
 
 ## [v0.9.0] - 2020-03-23
 

--- a/lib/vertex_client/version.rb
+++ b/lib/vertex_client/version.rb
@@ -1,3 +1,3 @@
 module VertexClient
-  VERSION = '0.9.1'
+  VERSION = '1.0.0'
 end

--- a/vertex_client.gemspec
+++ b/vertex_client.gemspec
@@ -1,14 +1,11 @@
-
-lib = File.expand_path("../lib", __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "vertex_client/version"
+require_relative "lib/vertex_client/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "vertex_client"
   spec.version       = VertexClient::VERSION
   spec.authors       = ["Custom Ink"]
   spec.email         = ["technology@customink.com"]
-  spec.required_ruby_version = '>= 2.1'
+  spec.required_ruby_version = '>= 2.5'
   spec.summary       = %q{A Ruby Gem to integrate with the Vertex Cloud API}
   spec.description   = %q{The Vertex Client Ruby Gem provides an interface to integrate with Vertex Cloud's SOAP API.}
   spec.homepage      = "https://github.com/customink/vertex_client"


### PR DESCRIPTION
### Description

This pull request bumps VertexClient to version 1.0.0, removing the support for all Ruby languages that are marked "end of life".
This allows us to focus on actively maintained versions only and not introduce potential security concerns.

Projects still running on versions older than 2.5 are recommended to upgrade their versions as soon as possible.

### Changes

- Bumped required Ruby version
- Removed `$LOAD_PATH` mingling

### Notes

**Upgrade to Ruby 2.5**
This is mainly a security concern. Especially since this gem is an open-source project, we want to reduce our maintenance as much as possible, and that means no longer supporting Ruby versions that have been marked as "end of life".
It's also a security liability to work on older versions as they do not receive updates and patches anymore

**$LOAD_PATH**
Our gem is not responsible for the load path, and we should make assumptions that we actually have the same structure when installed on a system. This is a responsibility handled by Bundler, and we should depend on it.