### PR TITLE
Map address validation exceptions to VertexClient::ValidationError

### DIFF
--- a/lib/vertex_client/payloads/base.rb
+++ b/lib/vertex_client/payloads/base.rb
@@ -3,6 +3,12 @@ module VertexClient
   module Payload
     class Base
 
+      # https://www.agiis.org/Links/ErrorCodes.htm
+      ADDRESS_VALIDATION_CODES = %w[
+        E101 E212 E213 E214 E216 E302 E412 E413 E420 E421 E422 E423 E425 E427 E428 E429 E430 E431
+        E432 E433 E434 E435 E436 E437 E439 E450 E451 E452 E453 E501 E502 E503 E504 E505 E600 E601
+      ].freeze
+
       attr_reader :params
 
       def initialize(params)
@@ -16,7 +22,17 @@ module VertexClient
         }
       end
 
+      def map_to_validation_exception!(exception)
+        return exception unless ADDRESS_VALIDATION_CODES.include?(fault_code(exception.message))
+
+        VertexClient::ValidationError.new("Invalid address: #{exception.message}")
+      end
+
       private
+
+      def fault_code(message)
+        message.match(/fault code=(?<code>\w+),/)&.[](:code)
+      end
 
       def request_key
         :"#{self.class.name.demodulize.underscore}_request"

--- a/lib/vertex_client/resources/base.rb
+++ b/lib/vertex_client/resources/base.rb
@@ -19,6 +19,8 @@ module VertexClient
 
       def response
         @response ||= connection.request(@payload.transform)
+      rescue Savon::SOAPFault => e
+        raise @payload.map_to_validation_exception!(e)
       end
 
       def connection

--- a/lib/vertex_client/version.rb
+++ b/lib/vertex_client/version.rb
@@ -1,3 +1,3 @@
 module VertexClient
-  VERSION = '0.9.1'
+  VERSION = '0.9.2'
 end

--- a/test/resources/base_test.rb
+++ b/test/resources/base_test.rb
@@ -1,10 +1,10 @@
 require 'test_helper'
 
 describe VertexClient::Resource::Base do
-  class VertexClient::Resource::MyTest  < VertexClient::Resource::Base
+  class VertexClient::Resource::MyTest < VertexClient::Resource::Base
     ENDPOINT = 'MyEndPoint'.freeze
   end
-  class VertexClient::Payload::MyTest   < VertexClient::Payload::Base
+  class VertexClient::Payload::MyTest < VertexClient::Payload::Base
     def validate!
     end
 
@@ -15,10 +15,12 @@ describe VertexClient::Resource::Base do
   class VertexClient::Response::MyTest  < VertexClient::Response::Base; end;
 
   let(:resource) { VertexClient::Resource::MyTest.new({ test: :ok })}
+  let(:connection) { resource.send(:connection) }
+  let(:payload) { resource.instance_variable_get(:@payload) }
 
   describe 'initialize' do
     it 'sets @payload with a new instance of payload_type' do
-      assert_kind_of VertexClient::Payload::MyTest, resource.instance_variable_get(:@payload)
+      assert_kind_of VertexClient::Payload::MyTest, payload
     end
   end
 
@@ -37,6 +39,39 @@ describe VertexClient::Resource::Base do
       it 'calls formatted_response' do
         resource.expects(:formatted_response)
         resource.result
+      end
+    end
+
+    describe 'when a soap fault is raised' do
+      let(:nori) { Nori.new(:strip_namespaces => true, :convert_tags_to => lambda { |tag| tag.snakecase.to_sym }) }
+      let(:address_fault) { fault_message(<<-ERROR) }
+        No tax areas were found during the lookup. The address fields are inconsistent for the specified asOfDate. (Street Information=1-252 AR / B- BTRY, Street Information 2=null, Postal Code=UNIT, City=APOAE, Sub Division=null, Main Division=09877-1368, Country=USA, As Of Date=20200419) Failed to cleanse address. (fault code=E412, fault code text=Primary name not found in directory.)
+      ERROR
+      let(:fault) { fault_message("The request cannot be processed") }
+      let(:address_soap_fault) { Savon::SOAPFault.new(HTTPI::Response.new(500, {}, address_fault), nori) }
+      let(:soap_fault) { Savon::SOAPFault.new(HTTPI::Response.new(500, {}, fault), nori) }
+
+      it 'maps to a validation exception for address errors' do
+        connection.stubs(:request).raises(address_soap_fault)
+        assert_raises(VertexClient::ValidationError) { resource.result }
+      end
+
+      it 'raises SOAPFault for non validation errors' do
+        connection.stubs(:request).raises(soap_fault)
+        assert_raises(Savon::SOAPFault) { resource.result }
+      end
+
+      def fault_message(fault_string)
+        <<-STRING
+          <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+             <soap:Body>
+                <soap:Fault>
+                   <faultcode>soapenv:Client</faultcode>
+                   <faultstring>#{fault_string}</faultstring>
+                </soap:Fault>
+             </soap:Body>
+          </soap:Envelope>
+        STRING
       end
     end
 


### PR DESCRIPTION
### Description
This PR attempts to convert common address validation errors masquerading as `Savon::SOAPFaults` into `VertexClient::ValidationErrors`.   This should allow the client to handle these exceptions and continue processing.

As an example, the Groups app would be able to use some default value for address validation errors, but because SOAPFaults could be a more serious networking issue processing ends and the user receives a 500 page.

<!--
Describe the relevant motivation and context for this change.
Please include a summary of the change as well as the issue that is fixed.
-->

### Changes

<!--
Please describe your code changes in detail for reviewers. Explain the technical solution you have provided and how it addresses the issue at hand.
-->
The error codes present in the address validation exceptions are found [here](https://www.agiis.org/Links/ErrorCodes.htm).  By parsing out the error code a `VertexClient::ValidationError` can be raised instead of a SOAPFault for the subset of the error codes pertaining to address validation. The `VertexClient::ValidationError` exception is already in use for other validation in this client.


### JIRA Ticket

<!-- Fill in the Jira ticket with the details of your feature -->
[XX-1234](https://customink.atlassian.net/browse/XX-1234)

### Screenshots

<!--
Please include any screenshots that communicate the visual story of the change that is being made.
-->

### Notes

<!--
Any notes that might be helpful for a reviewer to keep in mind while reading the changes.
-->
