### PR TITLE
Production ECR + latest CI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,10 +6,10 @@
 # CircleCI configuration, reducing the complexity of the entire block.
 # ---------------------------------------------------------------------------------------------------------------------
 docker_image: &docker_image
-  image: 322902370520.dkr.ecr.us-east-1.amazonaws.com/customink/base-ruby-ci:2.1-v2.1
+  image: 916869144969.dkr.ecr.us-east-1.amazonaws.com/customink/base-ruby-ci:2.1-v2.7
   aws_auth:
-    aws_access_key_id: ${STAGING_AWS_ACCESS_KEY_ID}
-    aws_secret_access_key: ${STAGING_AWS_SECRET_ACCESS_KEY}
+    aws_access_key_id: ${PRODUCTION_AWS_ACCESS_KEY_ID}
+    aws_secret_access_key: ${PRODUCTION_AWS_SECRET_ACCESS_KEY}
 
 # ---------------------------------------------------------------------------------------------------------------------
 # CircleCI Commands Configuration


### PR DESCRIPTION
- Use latest continuous integration Docker image
- Use production ECR (staging is obsolete)