### PR TITLE
Add support for isTaxOnlyAdjustmentIndicator flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file tracks all the changes (https://keepachangelog.com/en/1.0.0/) made to the client. This allows parsers such as Dependabot to provide a clean overview in pull requests.
 
+## [v0.9.2] - 2020-07-06
+
+#### Added
+
+- Quotation, Invoice and DistributeTax payloads now accept a `:tax_only_adjustment` param to make tax adjustments that need not be correlated with a total cost adjustment
+
 ## [v0.9.1] - 2020-03-24
 
 #### Added

--- a/lib/vertex_client/payloads/quotation.rb
+++ b/lib/vertex_client/payloads/quotation.rb
@@ -9,12 +9,13 @@ module VertexClient
       end
 
       def body
-        {
-          :'@transactionType' => SALE_TRANSACTION_TYPE,
-          line_item: params[:line_items].map.with_index do |line_item, index|
+        {}.tap do |data|
+          data[:'@transactionType'] = SALE_TRANSACTION_TYPE
+          data[:'@isTaxOnlyAdjustmentIndicator'] = true if params[:tax_only_adjustment]
+          data[:line_item] = params[:line_items].map.with_index do |line_item, index|
             transform_line_item(line_item, index, params)
           end
-        }
+        end
       end
 
       private

--- a/lib/vertex_client/version.rb
+++ b/lib/vertex_client/version.rb
@@ -1,3 +1,3 @@
 module VertexClient
-  VERSION = '0.9.1'
+  VERSION = '0.9.2'
 end

--- a/test/payloads/distribute_tax_test.rb
+++ b/test/payloads/distribute_tax_test.rb
@@ -1,11 +1,15 @@
 require 'test_helper'
+require_relative './tax_only_adjustment_examples'
 
 describe VertexClient::Payload::DistributeTax do
   include TestInput
+  extend VertexClient::Payload::TaxOnlyAdjustmentExamples
 
   let(:payload) do
     VertexClient::Payload::DistributeTax.new(distribute_tax_params)
   end
+
+  it_supports_tax_only_adjustments(:distribute_tax_params)
 
   it 'includes input_total_tax for line_items' do
     assert_equal '5.00', payload.body[:line_item].first[:input_total_tax]

--- a/test/payloads/invoice_test.rb
+++ b/test/payloads/invoice_test.rb
@@ -1,7 +1,10 @@
 require 'test_helper'
+require_relative './tax_only_adjustment_examples'
 
 describe VertexClient::Payload::Invoice do
   include TestInput
+  extend VertexClient::Payload::TaxOnlyAdjustmentExamples
+
   let(:payload) do
     VertexClient::Payload::Invoice.new(working_quote_params)
   end
@@ -12,6 +15,8 @@ describe VertexClient::Payload::Invoice do
       :'@documentDate' => '2018-11-15'
     }), payload.body
   end
+
+  it_supports_tax_only_adjustments(:working_quote_params)
 
   it 'supports sending is_tax_exempt to customer' do
     working_quote_params[:customer][:is_tax_exempt] = true

--- a/test/payloads/quotation_test.rb
+++ b/test/payloads/quotation_test.rb
@@ -1,7 +1,10 @@
 require 'test_helper'
+require_relative './tax_only_adjustment_examples'
 
 describe VertexClient::Payload::Quotation do
   include TestInput
+  extend VertexClient::Payload::TaxOnlyAdjustmentExamples
+
   let(:payload) do
     VertexClient::Payload::Quotation.new(working_quote_params)
   end
@@ -9,6 +12,8 @@ describe VertexClient::Payload::Quotation do
   it 'has a body' do
     assert_equal expected_payload_output, payload.body
   end
+
+  it_supports_tax_only_adjustments(:working_quote_params)
 
   it 'supports sending is_tax_exempt to customer' do
     working_quote_params[:customer][:is_tax_exempt] = true

--- a/test/payloads/tax_only_adjustment_examples.rb
+++ b/test/payloads/tax_only_adjustment_examples.rb
@@ -1,0 +1,21 @@
+module VertexClient::Payload::TaxOnlyAdjustmentExamples
+  def it_supports_tax_only_adjustments(param_name)
+    describe '@isTaxOnlyAdjustmentIndicator' do
+      let(:params) { public_send param_name }
+
+      it 'supports sending tax_only_adjustment to body' do
+        params[:tax_only_adjustment] = true
+        assert payload.body[:@isTaxOnlyAdjustmentIndicator]
+      end
+
+      it 'does not send tax_only_adjustment by default' do
+        refute payload.body[:@isTaxOnlyAdjustmentIndicator]
+      end
+
+      it 'does not send tax_only_adjustment when set to false' do
+        params[:tax_only_adjustment] = false
+        refute payload.body[:@isTaxOnlyAdjustmentIndicator]
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description

We have recently discovered that Vertex Cloud behaves unexpectedly when tax adjustments are made without corresponding adjustments to the principal amount (eg line item cost).

When exercising the changes in https://github.com/customink/stores/pull/830, we found that reversing out the tax amount while not specifying an exactly correlated change to the principal will cause vertex to attempt to reverse-engineer the change in principal that would have caused the tax amount change desired. In our specific case, returning all of the tax caused vertex to log our tax refund transactions as full refunds, leaving no principal amount left in the orders in question.

After discussing with the vertex team, it was apparent that we need to supply a boolean attribute `isTaxOnlyAdjustmentIndicator = "true"` to our request wrapper.

### Changes

- Implements `isTaxOnlyAdjustmentIndicator` as a param on the `Quotation`, `Invoice` and `DistributeTax` transaction types.
- Sent to our payload as `:tax_only_adjustment`
- Will set the key to `true` if the given value is truthy, or omit the key if not

### Notes
Should we be passing the given value instead of setting it only to true?
