### PR TITLE
[Bug] Quotation Fallback Response raises ArgumentError when line items are empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 This file tracks all the changes (https://keepachangelog.com/en/1.0.0/) made to the client. This allows parsers such as Dependabot to provide a clean overview in pull requests.
 
-## [v0.9.2] - 2020-07-06
+## [v0.9.2] - 2020-07-07
 
 #### Added
 
 - Quotation, Invoice and DistributeTax payloads now accept a `:tax_only_adjustment` param to make tax adjustments that need not be correlated with a total cost adjustment
+
+#### Changed
+
+- Fix a bug with fallback quotation responses where an empty set of line items would raise `ArgumentError`
 
 ## [v0.9.1] - 2020-03-24
 

--- a/lib/vertex_client/responses/quotation_fallback.rb
+++ b/lib/vertex_client/responses/quotation_fallback.rb
@@ -11,7 +11,7 @@ module VertexClient
       end
 
       def total_tax
-        @total_tax ||= line_items.sum(&:total_tax).round(2, :half_even)
+        @total_tax ||= line_items.sum(&:total_tax).to_d.round(2, :half_even)
       end
 
       def total

--- a/test/responses/quotation_fallback_test.rb
+++ b/test/responses/quotation_fallback_test.rb
@@ -18,12 +18,22 @@ describe VertexClient::Response::QuotationFallback do
     it 'is the sum of price from line_items' do
       assert_equal 135.5, response.subtotal.to_f
     end
+
+    it 'handles empty quotes' do
+      working_quote_params[:line_items] = []
+      assert_equal 0.0, response.subtotal.to_f
+    end
   end
 
   describe 'total_tax' do
     describe 'for US customer' do
       it 'is the sum of total_tax from line_items' do
         assert_equal 8.66, response.total_tax.to_f
+      end
+
+      it 'handles empty quotes' do
+        working_quote_params[:line_items] = []
+        assert_equal 0.0, response.total_tax.to_f
       end
     end
 


### PR DESCRIPTION
### Description

Fixes a bug introduced in 0.9.1 wherein an empty set of line items will attempt to round an integer with the `:half_even` round mode. Because round_mode is not implemented in most numerics this raises `ArgumentError` due to the arity of the call.

### Changes

- Coerce the total_tax to a decimal before attempting to round it
- Add regression tests for empty quotes around `subtotal` and `total_tax` in the fallback response object

Fixes #61 