### PR TITLE
Allow users to specify shipping terms and physical origin for line items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 This file tracks all the changes (https://keepachangelog.com/en/1.0.0/) made to the client. This allows parsers such as Dependabot to provide a clean overview in pull requests.
 
+## [v0.9.3] - 2020-09-29
+
+#### Added
+
+- Quotation payload now accepts a `:delivery_term` param to specify delivery terms for quotation request
+- Allow optional `physical_origin` attribute of `seller` in line item to help with specific VAT calculation use cases
+
+#### Changed
+
+- Update quotation validation rules to require either `state` (case of US address) or `country` (other countries) for line items with `seller` overrides that also specify `physical_origin`
+
 ## [v0.9.2] - 2020-07-07
 
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This file tracks all the changes (https://keepachangelog.com/en/1.0.0/) made to the client. This allows parsers such as Dependabot to provide a clean overview in pull requests.
 
-## [v0.9.3] - 2020-09-29
+## [v0.10.0] - 2020-09-29
 
 #### Added
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ The Vertex Client Ruby Gem provides an interface to integrate with _Vertex SMB_ 
 response = VertexClient.quotation(
   # The top level transaction date for all line items.
   date: "2018-11-15",
+  # Optional delivery term to specify correct pricing all line items.
+  delivery_term: "DAP",
   # The top level customer for all line items.
   customer: {
     code: "inky@customink.com",
@@ -31,7 +33,7 @@ response = VertexClient.quotation(
   },
   # The top level seller for all line items.
   seller: {
-    company: "CustomInk"
+    company: "CustomInk",
   },
   line_items: [
     {
@@ -62,6 +64,27 @@ response = VertexClient.quotation(
         state: "DC",
         postal_code: "20500"
       }
+    },
+    {
+      product_code: "5400",
+      product_class: "123456",
+      quantity: 2,
+      price: "35.40",
+      # Optional transaction date override for a line item.
+      date: "2018-11-14",
+      # Optional seller override for a line item.
+      seller: {
+        company: "CustomInkStores",
+        # Optional physical origin of a line item
+        physical_origin: {
+          address_1: "Prujezdna 320/62",
+          address_2: "",
+          city: "Praha",
+          state: "",
+          postal_code: "100 00",
+          country: "CZ"
+        }
+      }
     }
   ]
 )
@@ -71,7 +94,7 @@ response.total     #=> Total price plus total tax
 response.subtotal  #=> Total price before tax
 ```
 
-####  Customer data
+####  Location specific data (required for `:customer` and specified `:physical_origin` of `:seller` in `:line_items`)
 You are required to specify a `state` or a `country`. The client will raise an error if none is specified.
 
 ##### US address example

--- a/lib/vertex_client/payloads/base.rb
+++ b/lib/vertex_client/payloads/base.rb
@@ -25,14 +25,19 @@ module VertexClient
       def transform_customer(customer)
         remove_nils({
           :@isTaxExempt =>  customer[:is_tax_exempt],
-          destination: remove_nils({
-            street_address_1: customer[:address_1],
-            street_address_2: customer[:address_2],
-            city:             customer[:city],
-            main_division:    customer[:state],
-            postal_code:      customer[:postal_code],
-            country:          customer[:country]
-          })
+          destination: transform_address(customer)
+        })
+      end
+
+      def transform_address(address)
+        return unless address
+        remove_nils({
+          street_address_1: address[:address_1],
+          street_address_2: address[:address_2],
+          city:             address[:city],
+          main_division:    address[:state],
+          postal_code:      address[:postal_code],
+          country:          address[:country]
         })
       end
 

--- a/lib/vertex_client/payloads/quotation.rb
+++ b/lib/vertex_client/payloads/quotation.rb
@@ -43,7 +43,7 @@ module VertexClient
       end
 
       def sellers_physical_origin_lines(params)
-        [params[:line_items].map { |li| li.dig(:seller, :physical_origin) }].flatten.compact
+        [params[:line_items].map { |li| li[:seller] && li[:seller][:physical_origin] }].flatten.compact
       end
 
       # The hash argument is either customer or physical_origin object

--- a/lib/vertex_client/version.rb
+++ b/lib/vertex_client/version.rb
@@ -1,3 +1,3 @@
 module VertexClient
-  VERSION = '0.9.3'
+  VERSION = '0.10.0'
 end

--- a/lib/vertex_client/version.rb
+++ b/lib/vertex_client/version.rb
@@ -1,3 +1,3 @@
 module VertexClient
-  VERSION = '0.9.2'
+  VERSION = '0.9.3'
 end

--- a/test/payloads/quotation_test.rb
+++ b/test/payloads/quotation_test.rb
@@ -97,14 +97,14 @@ describe VertexClient::Payload::Quotation do
             VertexClient::Payload::Quotation.new(working_eu_quote_params).validate!
           end
           
-          it'raises if physical_origin is missing state' do
+          it 'raises if physical_origin is missing state' do
             working_eu_quote_params[:line_items][1][:seller][:physical_origin].delete(:state)
             assert_raises VertexClient::ValidationError do
               VertexClient::Payload::Quotation.new(working_eu_quote_params).body
             end
           end
 
-          it'raises if physical_origin is missing postal_code' do
+          it 'raises if physical_origin is missing postal_code' do
             working_eu_quote_params[:line_items][1][:seller][:physical_origin].delete(:postal_code)
             assert_raises VertexClient::ValidationError do
               VertexClient::Payload::Quotation.new(working_eu_quote_params).body


### PR DESCRIPTION
### Description

Adds support for specifying
-  shipping terms 
-  physical origin of any line item 

to allow clients to submit a better detailed request for sales tax quotation. This is especially useful for cases when some of the quoted line items are produced in another country or made by another seller. The sales tax for such line items can now be calculated properly - given the Vertex account is set up correctly for this feature - based on their physical origin. 

### Changes

- quotation payload supports `:delivery_term` param to pick shipping terms that should be applied to the particular quotation request
- `seller` override within a `line_item` object can now include a `physical_origin` which allows Vertex to calculate sales tax for the particular `line_item` correctly (if the Vertex account has been set up to support this - VAT collection registrations for the supported countries...)

