### PR TITLE
Don't require postal_code for non-US locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file tracks all the changes (https://keepachangelog.com/en/1.0.0/) made to the client. This allows parsers such as Dependabot to provide a clean overview in pull requests.
 
+## [v0.10.1] - 2021-04-29
+
+#### Changed
+
+- Loosen quotation validation rules to only require `postal_code` for `US` based locations.
+
 ## [v0.10.0] - 2020-09-29
 
 #### Added

--- a/README.md
+++ b/README.md
@@ -95,20 +95,22 @@ response.subtotal  #=> Total price before tax
 ```
 
 ####  Location specific data (required for `:customer` and specified `:physical_origin` of `:seller` in `:line_items`)
-You are required to specify a `state` or a `country`. The client will raise an error if none is specified.
+You are required to specify a `state` or a `country`. The client will raise an error if none is specified. 
+
+At the moment specifying state automatically implies `country` is `US`. For `US` locations `postal_code` is also required.
 
 ##### US address example
 ```ruby
  customer: {
     ...
     state: "NY",
-    # Optional, you don't have to explicitly specify a country once state is set
-    country: "US", 
+    postal_code: "10005",
+    country: "US", # Optional, you don't have to explicitly specify a country once state is set
     ...
   }
 ```
 ##### Non-US address example
-`state` is an optional attribute for non-US countries
+`state` and `postal_code` are optional attributes for non-US countries
 ```ruby
  customer: {
     ...

--- a/lib/vertex_client/payloads/quotation.rb
+++ b/lib/vertex_client/payloads/quotation.rb
@@ -48,7 +48,7 @@ module VertexClient
 
       # The hash argument is either customer or physical_origin object
       def destination_present?(hash)
-        (us_location_present?(hash) || other_location_present?(hash)) && hash[:postal_code].present?
+        us_location_present?(hash) || other_location_present?(hash)
       end
 
       def transform_line_item(line_item, number, defaults)
@@ -79,7 +79,7 @@ module VertexClient
       end
 
       def us_location_present?(customer)
-        customer[:state].present?
+        customer[:state].present? && customer[:postal_code].present?
       end
 
       def other_location_present?(customer)

--- a/lib/vertex_client/version.rb
+++ b/lib/vertex_client/version.rb
@@ -1,3 +1,3 @@
 module VertexClient
-  VERSION = '0.10.0'
+  VERSION = '0.10.1'
 end

--- a/test/payload_validator_test.rb
+++ b/test/payload_validator_test.rb
@@ -27,13 +27,7 @@ describe 'payload validation' do
 
       before(:each) do
         payload[:customer].delete(:state)
-      end
-
-      it 'raises an error when missing postal code' do
         payload[:customer].delete(:postal_code)
-        assert_raises VertexClient::ValidationError do
-          VertexClient::Payload::Quotation.new(payload)
-        end
       end
 
       it 'raises an error when missing country' do

--- a/test/payloads/quotation_test.rb
+++ b/test/payloads/quotation_test.rb
@@ -54,21 +54,15 @@ describe VertexClient::Payload::Quotation do
     describe 'for EU customer' do
       before(:each) do
         working_eu_quote_params[:customer].delete(:state)
+        working_eu_quote_params[:customer].delete(:postal_code)
       end
 
-      it 'is happy if country and postal_code are present on customer' do
+      it 'is happy if country is present on customer' do
         VertexClient::Payload::Quotation.new(working_eu_quote_params).validate!
       end
 
       it 'raises if the customer is missing country' do
         working_eu_quote_params[:customer].delete(:country)
-        assert_raises VertexClient::ValidationError do
-          VertexClient::Payload::Quotation.new(working_eu_quote_params).body
-        end
-      end
-
-      it 'raises if the customer is missing postal_code' do
-        working_eu_quote_params[:customer].delete(:postal_code)
         assert_raises VertexClient::ValidationError do
           VertexClient::Payload::Quotation.new(working_eu_quote_params).body
         end
@@ -117,24 +111,16 @@ describe VertexClient::Payload::Quotation do
             working_eu_quote_params[:line_items][1][:seller][:physical_origin] = {
               address_1: 'Prujezdna 320/62',
               city: 'Praha',
-              postal_code: '100 00',
               country: 'CZ'
             }
           end
 
-          it 'does not raise if country and postal_code are present' do
+          it 'does not raise if country is present' do
             VertexClient::Payload::Quotation.new(working_eu_quote_params).validate!
           end
 
           it 'raises if physical_origin is missing country' do
             working_eu_quote_params[:line_items][1][:seller][:physical_origin].delete(:country)
-            assert_raises VertexClient::ValidationError do
-              VertexClient::Payload::Quotation.new(working_eu_quote_params).body
-            end
-          end
-
-          it 'raises if physical_origin is missing postal_code' do
-            working_eu_quote_params[:line_items][1][:seller][:physical_origin].delete(:postal_code)
             assert_raises VertexClient::ValidationError do
               VertexClient::Payload::Quotation.new(working_eu_quote_params).body
             end


### PR DESCRIPTION
### Description

These changes will allow us to quote before our EU customer submits `postal_code` / `zip` in checkout  as these attributes don't have any impact on such quotation call. 

### Changes

- loosen quotation validation rules to only require `postal_code` for `US` based locations

