### PR TITLE
Add fallback rates for APO addresses, handle unknown US states more gracefully

### DIFF
--- a/lib/vertex_client/rates.rb
+++ b/lib/vertex_client/rates.rb
@@ -1,6 +1,8 @@
 module VertexClient
   RATES = {
     'US' => {
+      'AA' => '0.0',
+      'AE' => '0.0',
       'AL' => '0.0914',
       'AK' => '0.0',
       'AZ' => '0.0',

--- a/lib/vertex_client/responses/quotation_fallback.rb
+++ b/lib/vertex_client/responses/quotation_fallback.rb
@@ -27,14 +27,25 @@ module VertexClient
         )
       end
 
+      # see lib/vertex_client/rates.rb for hard-coded fallback rates
       def tax_amount(price, country, state)
-        if state.present? && RATES['US'].has_key?(state)
+        if known_us_state?(state)
           price * BigDecimal(RATES['US'][state])
-        elsif country.present? && RATES.has_key?(country)
+        elsif known_non_us_country?(country)
           price * BigDecimal(RATES[country])
         else
           BigDecimal('0.0')
         end
+      end
+
+      # state is in the United States and we have an explicit fallback
+      def known_us_state?(state)
+        state.present? && RATES['US'].has_key?(state)
+      end
+
+      # we have an explicit fallback for the country
+      def known_non_us_country?(country)
+        country.present? && country != 'US' && RATES.has_key?(country)
       end
 
       def tax_for_line_item(line_item)

--- a/lib/vertex_client/version.rb
+++ b/lib/vertex_client/version.rb
@@ -1,3 +1,3 @@
 module VertexClient
-  VERSION = '0.10.1'
+  VERSION = '0.10.2'
 end

--- a/test/responses/quotation_fallback_test.rb
+++ b/test/responses/quotation_fallback_test.rb
@@ -26,6 +26,20 @@ describe VertexClient::Response::QuotationFallback do
   end
 
   describe 'total_tax' do
+    describe 'for country-less customer' do
+      let(:countryless_params) do
+        working_quote_params.tap do |wqp|
+          wqp[:customer].delete(:country)
+          wqp[:line_items][1][:customer].delete(:country)
+        end
+      end
+      let(:payload) { VertexClient::Payload::QuotationFallback.new(countryless_params) }
+
+      it 'assumes they are from the US' do
+        assert_equal 8.66, response.total_tax.to_f
+      end
+    end
+
     describe 'for US customer' do
       it 'is the sum of total_tax from line_items' do
         assert_equal 8.66, response.total_tax.to_f
@@ -35,14 +49,35 @@ describe VertexClient::Response::QuotationFallback do
         working_quote_params[:line_items] = []
         assert_equal 0.0, response.total_tax.to_f
       end
+
+      it 'handle unrecognized states' do
+        working_quote_params[:customer][:state] = 'XY'
+        working_quote_params[:line_items][1][:customer][:state] = 'XY'
+        assert_equal 0.0, response.total_tax.to_f
+      end
     end
 
     describe 'for EU customer' do
       let(:payload) { VertexClient::Payload::QuotationFallback.new(working_eu_quote_params) }
-      let(:response) { VertexClient::Response::QuotationFallback.new(payload) }
 
       it 'is the sum of total_tax from line_items' do
         assert_equal 12.54, response.total_tax.to_f
+      end
+    end
+
+    describe 'for other countries' do
+      let(:intl_params) do
+        working_quote_params.tap do |wqp|
+          wqp[:customer][:country] = 'TZ'
+          wqp[:customer].delete(:state)
+          wqp[:line_items][1][:customer][:country] = 'TZ'
+          wqp[:line_items][1][:customer].delete(:state)
+        end
+      end
+      let(:payload) { VertexClient::Payload::QuotationFallback.new(intl_params) }
+
+      it 'is the sum of total_tax from line_items' do
+        assert_equal 0.0, response.total_tax.to_f
       end
     end
   end


### PR DESCRIPTION
### Description
Addressing an issue found during the QA of https://github.com/customink/checkout/pull/383.

APO addresses do not play nice with the Vertex Client fallback rates behavior. The reason for this was twofold:

1. The client does not provide explicit fallback rates for APO addresses.
2. The client does not properly handle addresses that are `US` but have a state for which there is no explicit fallback rate.

This PR addresses both issues.

### Changes
* Add explicit fallback rates for the two APO state codes, `AA` and `AE`
* Change fallback logic to not try to get a fallback rate from the `US` fallback hash when country is United States and the state is unrecognized
* Version bump from `0.10.1` to `0.10.2`

### Ticket
https://customink.monday.com/boards/2768809476/pulses/3847019239