### PR TITLE
Surface original Vertex errors via new bang methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This file tracks all the changes (https://keepachangelog.com/en/1.0.0/) made to the client. This allows parsers such as Dependabot to provide a clean overview in pull requests.
 
+## [v0.12.0] - 2024-08-07
+
+#### Added
+
+- Added `quotation!`, `invoice!`, `distribute_tax!`, `tax_area!` class methods to `VertexClient` that raise `Savon::SOAPFault` errors when errors are returned from the Vertex SOAP API
+  - Existing non-bang methods receive `nil` internally and return `fallback_response` defined in each resource
+
 ## [v0.11.0] - 2024-04-03
 
 #### Changed

--- a/lib/vertex_client.rb
+++ b/lib/vertex_client.rb
@@ -65,16 +65,32 @@ module VertexClient
       Resource::Quotation.new(payload).result
     end
 
+    def quotation!(payload)
+      Resource::Quotation.new(payload).result!
+    end
+
     def invoice(payload)
       Resource::Invoice.new(payload).result
+    end
+
+    def invoice!(payload)
+      Resource::Invoice.new(payload).result!
     end
 
     def distribute_tax(payload)
       Resource::DistributeTax.new(payload).result
     end
 
+    def distribute_tax!(payload)
+      Resource::DistributeTax.new(payload).result!
+    end
+
     def tax_area(payload)
       Resource::TaxArea.new(payload).result
+    end
+
+    def tax_area!(payload)
+      Resource::TaxArea.new(payload).result!
     end
 
     def circuit

--- a/lib/vertex_client/resources/base.rb
+++ b/lib/vertex_client/resources/base.rb
@@ -2,31 +2,44 @@ require 'active_support'
 module VertexClient
   module Resource
     class Base
+      class NotImplementedError < StandardError; end
 
       def initialize(params)
         @payload = payload_type.new(params)
       end
 
       def result
-        @result ||= (response ? formatted_response : fallback_response)
+        @result ||= (formatted_response(response) || fallback_response)
+      end
+
+      def result!
+        formatted_response(response!)
       end
 
       def config_key
         demodulized_class_name.underscore.to_sym
       end
 
+      def fallback_response
+        raise NotImplementedError
+      end
+
       private
 
       def response
-        @response ||= connection.request(@payload.transform)
+        connection.request(@payload.transform)
+      end
+
+      def response!
+        connection.request!(@payload.transform)
       end
 
       def connection
         @connection ||= Connection.new(self.class::ENDPOINT, config_key)
       end
 
-      def formatted_response
-        response_type.new(response)
+      def formatted_response(raw_response)
+        response_type.new(raw_response) if raw_response
       end
 
       def payload_type

--- a/lib/vertex_client/version.rb
+++ b/lib/vertex_client/version.rb
@@ -1,3 +1,3 @@
 module VertexClient
-  VERSION = '0.11.0'
+  VERSION = '0.12.0'
 end

--- a/test/resources/base_test.rb
+++ b/test/resources/base_test.rb
@@ -3,6 +3,10 @@ require 'test_helper'
 describe VertexClient::Resource::Base do
   class VertexClient::Resource::MyTest  < VertexClient::Resource::Base
     ENDPOINT = 'MyEndPoint'.freeze
+
+    def fallback_response
+      { fall: :back }
+    end
   end
   class VertexClient::Payload::MyTest   < VertexClient::Payload::Base
     def validate!
@@ -51,11 +55,33 @@ describe VertexClient::Resource::Base do
     end
   end
 
+  describe 'result!' do
+    describe 'without exceptions' do
+      before do
+        resource.stubs(:response!).returns({ test: :ok })
+      end
+
+      it 'returns a formatted response' do
+        resource.expects(:formatted_response)
+        resource.result!
+      end
+    end
+
+    describe 'with exceptions' do
+      before do
+        resource.stubs(:response!).raises(StandardError)
+      end
+
+      it 'raises the exception' do
+        assert_raises(StandardError) { resource.result! }
+      end
+    end
+  end
+
   describe 'formatted_response' do
     it 'returns a new response of the proper type' do
-      resource.expects(:response).returns({test: :ok})
       VertexClient::Response::MyTest.expects(:new).with({test: :ok})
-      resource.send(:formatted_response)
+      resource.send(:formatted_response, {test: :ok})
     end
   end
 end

--- a/test/vertex_client_test.rb
+++ b/test/vertex_client_test.rb
@@ -23,11 +23,25 @@ describe VertexClient do
     assert VertexClient.quotation(working_quote_params)
   end
 
+  it 'does a quotation!' do
+    VertexClient::Resource::Quotation.expects(:new)
+      .with(working_quote_params)
+      .returns(stub(result!: true))
+    assert VertexClient.quotation!(working_quote_params)
+  end
+
   it 'does invoice' do
     VertexClient::Resource::Invoice.expects(:new)
       .with(working_quote_params)
       .returns(stub(result: true))
     assert VertexClient.invoice(working_quote_params)
+  end
+
+  it 'does invoice!' do
+    VertexClient::Resource::Invoice.expects(:new)
+      .with(working_quote_params)
+      .returns(stub(result!: true))
+    assert VertexClient.invoice!(working_quote_params)
   end
 
   it 'does distribute_tax' do
@@ -37,11 +51,25 @@ describe VertexClient do
     assert VertexClient.distribute_tax(working_quote_params)
   end
 
+  it 'does distribute_tax!' do
+    VertexClient::Resource::DistributeTax.expects(:new)
+      .with(working_quote_params)
+      .returns(stub(result!: true))
+    assert VertexClient.distribute_tax!(working_quote_params)
+  end
+
   it 'does tax_area' do
     VertexClient::Resource::TaxArea.expects(:new)
       .with(working_quote_params)
       .returns(stub(result: true))
     assert VertexClient.tax_area(working_quote_params)
+  end
+
+  it 'does tax_area!' do
+    VertexClient::Resource::TaxArea.expects(:new)
+      .with(working_quote_params)
+      .returns(stub(result!: true))
+    assert VertexClient.tax_area!(working_quote_params)
   end
 
   describe 'circuit' do


### PR DESCRIPTION
### Stakeholder Overview _[(learn more)](https://app.getguru.com/card/TGyLkrnc/Pull-Review-Stakeholder-Overview)_

As part of the Hybrid GO Migration work in stores, we've begun issuing tax distributions at the time of fulfillment of items to account for any changes to shipping address and tax amount between the time of purchase and the time of fulfillment.

That tax distribution process is ignorant of the prior state of the tax invoice originally reported to Vertex, and relies on idempotency to correct the tax invoice data in Vertex.

While this has worked well in most cases, we found that the Vertex API rejects tax distribution requests with an error response if there is no difference to the tax invoice data in Vertex vs. the data in the new tax distribution request.

Today, this results in a generic `VertexClient::ServerError` returned by the VertexClient to the stores app due to the masking of the raw Vertex API error via the `fallback_response` structure [within the resource models](https://github.com/customink/vertex_client/blob/master/lib/vertex_client/resources/invoice.rb).

While the raw error message returned by Vertex in this case is:
```
(soapenv:Client) Input tax has been specified but there are no taxes to which it may be distributed. Please verify the details for this transaction. (Savon::SOAPFault)
```

In order to differentiate this error with other errors related to Vertex API outages, etc. and handle this case accordingly (no-op, prevent reprocessing of jobs) we need access to the raw error message returned by Vertex.

We achieve this by adding `!` request methods that bypass the `fallback_response` structure of the existing request methods and raising the lower level [Savon::SOAPFault](https://github.com/savonrb/savon/blob/main/lib/savon/soap_fault.rb) error to the application. The specific error type and message can then be accessed via the [to_hash](https://github.com/savonrb/savon/blob/main/lib/savon/soap_fault.rb#L34) method and custom error handling can be performed.

### Risk Estimate _[(learn more)](https://app.getguru.com/card/iMnRRRjT/Pull-Request-Risk-Estimate)_

Relatively low risk as this is mostly the addition of new methods alongside existing ones, with release controlled by gem versioning.

### Changes

- Added `quotation!`, `invoice!`, `distribute_tax!`, `tax_area!` class methods to `VertexClient` that raise `Savon::SOAPFault` errors when errors are returned from the Vertex SOAP API

### Notes

Relies on the Circuitbox circuit `exception` option, which was previously set to `false` across the board

##### Library-Specific

- [x] Increment the changelog (CHANGELOG.md)
- [x] Increment the version number (lib/version.rb)
- [ ] [Release & Tag][release] the version above in Github