### PR TITLE
v0.11.1 -> v0.11.2: take country into account when determining state fallback rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file tracks all the changes (https://keepachangelog.com/en/1.0.0/) made to the client. This allows parsers such as Dependabot to provide a clean overview in pull requests.
 
+## [v0.11.2] - 2025-01-16
+
+#### Changed
+
+- Take country code into account when determining applicable state tax rate in fallback quotation context.
+
 ## [v0.11.1] - 2024-12-05
 
 #### Changed

--- a/lib/vertex_client/responses/quotation_fallback.rb
+++ b/lib/vertex_client/responses/quotation_fallback.rb
@@ -29,23 +29,18 @@ module VertexClient
 
       # see lib/vertex_client/rates.rb for hard-coded fallback rates
       def tax_amount(price, country, state)
-        if known_us_state?(state)
+        if domestic?(country) && state.present? && RATES['US'].has_key?(state)
           price * BigDecimal(RATES['US'][state])
-        elsif known_non_us_country?(country)
+        elsif !domestic?(country) && country.present? && RATES.has_key?(country)
           price * BigDecimal(RATES[country])
         else
           BigDecimal('0.0')
         end
       end
 
-      # state is in the United States and we have an explicit fallback
-      def known_us_state?(state)
-        state.present? && RATES['US'].has_key?(state)
-      end
-
-      # we have an explicit fallback for the country
-      def known_non_us_country?(country)
-        country.present? && country != 'US' && RATES.has_key?(country)
+      def domestic?(country)
+        # we assume a country-less customer is from the US
+        country.nil? || country == 'US'
       end
 
       def tax_for_line_item(line_item)

--- a/lib/vertex_client/version.rb
+++ b/lib/vertex_client/version.rb
@@ -1,3 +1,3 @@
 module VertexClient
-  VERSION = '0.11.1'
+  VERSION = '0.11.2'
 end

--- a/test/responses/quotation_fallback_test.rb
+++ b/test/responses/quotation_fallback_test.rb
@@ -80,6 +80,28 @@ describe VertexClient::Response::QuotationFallback do
         assert_equal 0.0, response.total_tax.to_f
       end
     end
+
+    describe 'for a country with a state code that collides with a US state code' do
+      let(:params) do
+        working_quote_params.tap do |wqp|
+          wqp[:customer][:address_1] = 'Miguel Angel Blanco 2 4C'
+          wqp[:customer][:city] = 'Valladolid'
+          wqp[:customer][:state] = 'VA'
+          wqp[:customer][:postal_code] = '47014'
+          wqp[:customer][:country] = 'ES'
+          wqp[:line_items][1][:customer][:address_1] = 'Miguel Angel Blanco 2 4C'
+          wqp[:line_items][1][:customer][:city] = 'Valladolid'
+          wqp[:line_items][1][:customer][:state] = 'VA'
+          wqp[:line_items][1][:customer][:postal_code] = '47014'
+          wqp[:line_items][1][:customer][:country] = 'ES'
+        end
+      end
+      let(:payload) { VertexClient::Payload::QuotationFallback.new(params) }
+
+      it 'does not use the US rates' do
+        assert_equal 0.0, response.total_tax.to_f
+      end
+    end
   end
 
   describe 'total' do


### PR DESCRIPTION
### Stakeholder Overview _[(learn more)](https://app.getguru.com/card/TGyLkrnc/Pull-Review-Stakeholder-Overview)_
- When testing the update of `vertex_client` to v0.11.1 in [the `checkout` app](https://github.com/customink/checkout/pull/573), @lbeougher discovered a bug wherein an order shipping to Valladolid, Spain was being taxed at 5.65% (when it should've been taxed at 0%). Upon closer inspection, it was determined that this was the Virginia state tax, and it was being applied due to a collision in the state code (`'VA'`, in this case). This PR fixes this pre-existing bug by taking a state's country into account when determine the proper fallback tax rate to apply.

### Risk Estimate _[(learn more)](https://app.getguru.com/card/iMnRRRjT/Pull-Request-Risk-Estimate)_
- ✅ Negligible risk!

### Changes
- First check that the country code is domestic before determining which state tax rate to apply.

### Monday Item
- [Update `vertex_client` from v0.11.1 to v0.11.2](https://customink.monday.com/boards/5878799126/pulses/8287651653)