### PR TITLE
align code with tag / release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # VertexClient Changelog
 
 This file tracks all the changes (https://keepachangelog.com/en/1.0.0/) made to the client. This allows parsers such as Dependabot to provide a clean overview in pull requests.
+## [v0.11.3] - 2025-01-21
+
+#### Changed
+
+- Fix misalignment between v0.11.2 tag / release and current code state.
 
 ## [v0.11.2] - 2025-01-16
 

--- a/lib/vertex_client/version.rb
+++ b/lib/vertex_client/version.rb
@@ -1,3 +1,3 @@
 module VertexClient
-  VERSION = '0.11.2'
+  VERSION = '0.11.3'
 end


### PR DESCRIPTION
### Stakeholder Overview _[(learn more)](https://app.getguru.com/card/TGyLkrnc/Pull-Review-Stakeholder-Overview)_
- Version 0.11.2 mistakenly had its tag released before the version file and changelog file had been changed, leading to a misalignment in the tag and the version that was showing up in the `Gemfile.lock` files of the apps that use this gem. This PR aims to realign the tag / release version with the current code state.

### Risk Estimate _[(learn more)](https://app.getguru.com/card/iMnRRRjT/Pull-Request-Risk-Estimate)_
- ✅ Negligible risk!

### Changes
- Bump gem from v0.11.2 -> v0.11.3

### Monday Item
- [Bump `vertex_client` from 0.11.2 -> 0.11.3](https://customink.monday.com/boards/5878799126/pulses/8291420946)