### PR TITLE
AC-585: Add optional `posting_date` to Invoice payload (`v0.12.0`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # VertexClient Changelog
 
 This file tracks all the changes (https://keepachangelog.com/en/1.0.0/) made to the client. This allows parsers such as Dependabot to provide a clean overview in pull requests.
+## [v0.12.0] - 2026-03-12
+
+#### Added
+
+- Add optional `posting_date` parameter to Invoice payload. When provided, sets `@postingDate` on the `InvoiceRequest` element for Vertex tax reporting period control. Omitting `posting_date` preserves existing behavior (no `@postingDate` attribute sent).
+
 ## [v0.11.3] - 2025-01-21
 
 #### Changed

--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ VertexClient.invoice(
   # Vertex's Document Number is a unique referencial identifier for this invoice.
   document_number: "unique-identifier-1a43b",
 
+  # Optional posting date for controlling the Vertex tax reporting period (e.g. ship date).
+  # Defaults to documentDate when omitted.
+  posting_date: "2018-11-16",
+
   # ... All of the of the payload from quotation here ...
 )
 

--- a/lib/vertex_client/payloads/invoice.rb
+++ b/lib/vertex_client/payloads/invoice.rb
@@ -11,10 +11,12 @@ module VertexClient
       end
 
       def body
-        super.merge({
-           :'@documentNumber' => params[:document_number],
-           :'@documentDate'   => params[:date]
-         })
+        b = super.merge({
+          :'@documentNumber' => params[:document_number],
+          :'@documentDate'   => params[:date]
+        })
+        b[:'@postingDate'] = params[:posting_date] if params[:posting_date].present?
+        b
       end
 
       def document_number_missing?

--- a/lib/vertex_client/version.rb
+++ b/lib/vertex_client/version.rb
@@ -1,3 +1,3 @@
 module VertexClient
-  VERSION = '0.11.3'
+  VERSION = '0.12.0'
 end

--- a/test/payloads/invoice_test.rb
+++ b/test/payloads/invoice_test.rb
@@ -16,6 +16,16 @@ describe VertexClient::Payload::Invoice do
     }), payload.body
   end
 
+  it 'includes @postingDate in body when posting_date is provided' do
+    working_quote_params[:posting_date] = '2026-03-12'
+    payload = VertexClient::Payload::Invoice.new(working_quote_params)
+    assert_equal '2026-03-12', payload.body[:'@postingDate']
+  end
+
+  it 'omits @postingDate from body when posting_date is not provided' do
+    assert_nil payload.body[:'@postingDate']
+  end
+
   it_supports_tax_only_adjustments(:working_quote_params)
 
   it 'supports sending is_tax_exempt to customer' do


### PR DESCRIPTION
## Summary

- Adds optional `posting_date` parameter to the `Invoice` payload, mapping to `@postingDate` on the `InvoiceRequest` SOAP element
- When omitted, behavior is unchanged — no `@postingDate` attribute is sent
- Bumps version `0.11.3` → `0.12.0`

## Jira

[AC-585 — Deploy vertex_client gem with postingDate support](https://customink.atlassian.net/browse/AC-585)

## Test plan

- [x] New test: `@postingDate` is set in body when `posting_date` is provided
- [x] New test: `@postingDate` is absent (nil) when `posting_date` is not provided
- [x] All existing invoice tests pass (no regressions to `@documentDate` / `@documentNumber`)
- [x] CI passes

## Staging verification (Beast)

Ran `VertexClient.invoice` with `posting_date: Date.new(2025, 1, 15)` against purchase `online-stores-725573` (VA, 93635) via the Online Stores Rails console on Beast.

**Payload sent:**
- `document_number`: `online-stores-725573`
- `date`: `2026-03-12`
- `posting_date`: `2025-01-15`
- 1 active item + shipping

**Response:**

| Line item | Qty | Price | Tax |
|---|---|---|---|
| `124200` | 10 | $200.00 | $17.50 |
| `shipping_handling` | 1 | $6.95 | $0.60 |
| **Total** | | **$206.95** | **$18.10** |

Vertex accepted the request without error and returned a valid tax response. ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)